### PR TITLE
Remove logging time

### DIFF
--- a/cmd/fly-autoscaler/serve.go
+++ b/cmd/fly-autoscaler/serve.go
@@ -112,11 +112,18 @@ Arguments:
 	}
 
 	// Initialize logging.
-	hopt := &slog.HandlerOptions{Level: slog.LevelInfo}
+	hopt := &slog.HandlerOptions{Level: slog.LevelInfo, ReplaceAttr: removeSlogTime}
 	if c.Config.Verbose {
 		hopt.Level = slog.LevelDebug
 	}
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, hopt)))
 
 	return nil
+}
+
+func removeSlogTime(groups []string, a slog.Attr) slog.Attr {
+	if a.Key == slog.TimeKey && len(groups) == 0 {
+		return slog.Attr{}
+	}
+	return a
 }


### PR DESCRIPTION
The log timestamp is already tracked in `fly logs` so this removes the redundancy.