### PR TITLE
Scale via create/destroy

### DIFF
--- a/cmd/fly-autoscaler/main.go
+++ b/cmd/fly-autoscaler/main.go
@@ -162,6 +162,10 @@ func NewConfigFromEnv() (*Config, error) {
 	return c, nil
 }
 
+func (c *Config) IsCreatedMachineCountDefined() bool {
+	return c.CreatedMachineN != "" || c.MinCreatedMachineN != "" || c.MaxCreatedMachineN != ""
+}
+
 func (c *Config) GetMinCreatedMachineN() string {
 	if v := c.CreatedMachineN; v != "" {
 		return v
@@ -174,6 +178,10 @@ func (c *Config) GetMaxCreatedMachineN() string {
 		return v
 	}
 	return c.MaxCreatedMachineN
+}
+
+func (c *Config) IsStartedMachineCountDefined() bool {
+	return c.StartedMachineN != "" || c.MinStartedMachineN != "" || c.MaxStartedMachineN != ""
 }
 
 func (c *Config) GetMinStartedMachineN() string {
@@ -195,24 +203,54 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("app name required")
 	}
 
-	// Ensure either a single machine count is defined or a range.
-	if c.StartedMachineN != "" && (c.MinStartedMachineN != "" || c.MaxStartedMachineN != "") {
-		return fmt.Errorf("cannot define started machine count and min/max started machine count")
+	if !c.IsCreatedMachineCountDefined() && !c.IsStartedMachineCountDefined() {
+		return fmt.Errorf("must define either created machine count or started machine count")
 	}
-	if c.StartedMachineN == "" && c.MinStartedMachineN == "" && c.MaxStartedMachineN == "" {
-		return fmt.Errorf("started machine count required")
+	if err := c.validateCreatedMachineCount(); err != nil {
+		return err
 	}
-	if c.MinStartedMachineN != "" && c.MaxStartedMachineN == "" {
-		return fmt.Errorf("max started machine count required if min started machine count is defined")
-	}
-	if c.MinStartedMachineN == "" && c.MaxStartedMachineN != "" {
-		return fmt.Errorf("min started machine count required if max started machine count is defined")
+	if err := c.validateStartedMachineCount(); err != nil {
+		return err
 	}
 
 	for i, collectorConfig := range c.MetricCollectors {
 		if err := collectorConfig.Validate(); err != nil {
 			return fmt.Errorf("metric-collectors[%d]: %w", i, err)
 		}
+	}
+	return nil
+}
+
+func (c *Config) validateCreatedMachineCount() error {
+	if !c.IsCreatedMachineCountDefined() {
+		return nil
+	}
+
+	if c.CreatedMachineN != "" && (c.MinCreatedMachineN != "" || c.MaxCreatedMachineN != "") {
+		return fmt.Errorf("cannot define created machine count and min/max created machine count")
+	}
+	if c.MinCreatedMachineN != "" && c.MaxCreatedMachineN == "" {
+		return fmt.Errorf("max created machine count required if min created machine count is defined")
+	}
+	if c.MinCreatedMachineN == "" && c.MaxCreatedMachineN != "" {
+		return fmt.Errorf("min created machine count required if max created machine count is defined")
+	}
+	return nil
+}
+
+func (c *Config) validateStartedMachineCount() error {
+	if !c.IsStartedMachineCountDefined() {
+		return nil
+	}
+
+	if c.StartedMachineN != "" && (c.MinStartedMachineN != "" || c.MaxStartedMachineN != "") {
+		return fmt.Errorf("cannot define started machine count and min/max started machine count")
+	}
+	if c.MinStartedMachineN != "" && c.MaxStartedMachineN == "" {
+		return fmt.Errorf("max started machine count required if min started machine count is defined")
+	}
+	if c.MinStartedMachineN == "" && c.MaxStartedMachineN != "" {
+		return fmt.Errorf("min started machine count required if max started machine count is defined")
 	}
 	return nil
 }

--- a/cmd/fly-autoscaler/main.go
+++ b/cmd/fly-autoscaler/main.go
@@ -106,6 +106,10 @@ func registerConfigPathFlag(fs *flag.FlagSet) *string {
 
 type Config struct {
 	AppName            string        `yaml:"app-name"`
+	Regions            []string      `yaml:"regions"`
+	CreatedMachineN    string        `yaml:"created-machine-count"`
+	MinCreatedMachineN string        `yaml:"min-created-machine-count"`
+	MaxCreatedMachineN string        `yaml:"max-created-machine-count"`
 	StartedMachineN    string        `yaml:"started-machine-count"`
 	MinStartedMachineN string        `yaml:"min-started-machine-count"`
 	MaxStartedMachineN string        `yaml:"max-started-machine-count"`
@@ -125,10 +129,17 @@ func NewConfig() *Config {
 func NewConfigFromEnv() (*Config, error) {
 	c := NewConfig()
 	c.AppName = os.Getenv("FAS_APP_NAME")
+	c.CreatedMachineN = os.Getenv("FAS_CREATED_MACHINE_COUNT")
+	c.MinCreatedMachineN = os.Getenv("FAS_MIN_CREATED_MACHINE_COUNT")
+	c.MaxCreatedMachineN = os.Getenv("FAS_MAX_CREATED_MACHINE_COUNT")
 	c.StartedMachineN = os.Getenv("FAS_STARTED_MACHINE_COUNT")
 	c.MinStartedMachineN = os.Getenv("FAS_MIN_STARTED_MACHINE_COUNT")
 	c.MaxStartedMachineN = os.Getenv("FAS_MAX_STARTED_MACHINE_COUNT")
 	c.APIToken = os.Getenv("FAS_API_TOKEN")
+
+	if s := os.Getenv("FAS_REGIONS"); s != "" {
+		c.Regions = strings.Split(s, ",")
+	}
 
 	if s := os.Getenv("FAS_INTERVAL"); s != "" {
 		d, err := time.ParseDuration(s)
@@ -149,6 +160,20 @@ func NewConfigFromEnv() (*Config, error) {
 	}
 
 	return c, nil
+}
+
+func (c *Config) GetMinCreatedMachineN() string {
+	if v := c.CreatedMachineN; v != "" {
+		return v
+	}
+	return c.MinCreatedMachineN
+}
+
+func (c *Config) GetMaxCreatedMachineN() string {
+	if v := c.CreatedMachineN; v != "" {
+		return v
+	}
+	return c.MaxCreatedMachineN
 }
 
 func (c *Config) GetMinStartedMachineN() string {

--- a/cmd/fly-autoscaler/main_test.go
+++ b/cmd/fly-autoscaler/main_test.go
@@ -46,3 +46,54 @@ func TestConfig_Parse(t *testing.T) {
 		t.Fatalf("MC[0].Token=%v, want %v", got, want)
 	}
 }
+
+func TestConfig_Validate(t *testing.T) {
+	t.Run("CreatedOrStartedMachineCount", func(t *testing.T) {
+		c := &main.Config{AppName: "myapp"}
+		if err := c.Validate(); err == nil || err.Error() != `must define either created machine count or started machine count` {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("CreatedMachineCount", func(t *testing.T) {
+		t.Run("TooManyDefined", func(t *testing.T) {
+			c := &main.Config{AppName: "myapp", CreatedMachineN: "1", MinCreatedMachineN: "1"}
+			if err := c.Validate(); err == nil || err.Error() != `cannot define created machine count and min/max created machine count` {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+		t.Run("MinNotMax", func(t *testing.T) {
+			c := &main.Config{AppName: "myapp", MinCreatedMachineN: "1"}
+			if err := c.Validate(); err == nil || err.Error() != `max created machine count required if min created machine count is defined` {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+		t.Run("MaxNotMin", func(t *testing.T) {
+			c := &main.Config{AppName: "myapp", MaxCreatedMachineN: "1"}
+			if err := c.Validate(); err == nil || err.Error() != `min created machine count required if max created machine count is defined` {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	})
+
+	t.Run("StartedMachineCount", func(t *testing.T) {
+		t.Run("TooManyDefined", func(t *testing.T) {
+			c := &main.Config{AppName: "myapp", StartedMachineN: "1", MinStartedMachineN: "1"}
+			if err := c.Validate(); err == nil || err.Error() != `cannot define started machine count and min/max started machine count` {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+		t.Run("MinNotMax", func(t *testing.T) {
+			c := &main.Config{AppName: "myapp", MinStartedMachineN: "1"}
+			if err := c.Validate(); err == nil || err.Error() != `max started machine count required if min started machine count is defined` {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+		t.Run("MaxNotMin", func(t *testing.T) {
+			c := &main.Config{AppName: "myapp", MaxStartedMachineN: "1"}
+			if err := c.Validate(); err == nil || err.Error() != `min started machine count required if max started machine count is defined` {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	})
+}

--- a/cmd/fly-autoscaler/serve.go
+++ b/cmd/fly-autoscaler/serve.go
@@ -65,7 +65,34 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) (err error) {
 	r.RegisterPromMetrics(prometheus.DefaultRegisterer)
 	c.reconciler = r
 
-	slog.Info("beginning reconciliation loop")
+	attrs := []any{
+		slog.Duration("interval", r.Interval),
+		slog.Int("collectors", len(r.Collectors)),
+	}
+
+	if len(r.Regions) > 0 {
+		attrs = append(attrs, slog.Any("regions", r.Regions))
+	}
+
+	if r.MinCreatedMachineN == r.MaxCreatedMachineN {
+		attrs = append(attrs, slog.String("created", r.MinCreatedMachineN))
+	} else if r.MinCreatedMachineN != "" || r.MaxCreatedMachineN != "" {
+		attrs = append(attrs, slog.Group("created",
+			slog.String("min", r.MinCreatedMachineN),
+			slog.String("max", r.MaxCreatedMachineN),
+		))
+	}
+
+	if r.MinStartedMachineN == r.MaxStartedMachineN {
+		attrs = append(attrs, slog.String("started", r.MinStartedMachineN))
+	} else if r.MinStartedMachineN != "" || r.MaxStartedMachineN != "" {
+		attrs = append(attrs, slog.Group("started",
+			slog.String("min", r.MinStartedMachineN),
+			slog.String("max", r.MaxStartedMachineN),
+		))
+	}
+
+	slog.Info("reconciler initialized, beginning loop", attrs...)
 	r.Start()
 
 	go c.serveMetricsServer(ctx)

--- a/cmd/fly-autoscaler/serve.go
+++ b/cmd/fly-autoscaler/serve.go
@@ -59,6 +59,7 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) (err error) {
 	r.MaxCreatedMachineN = c.Config.GetMaxCreatedMachineN()
 	r.MinStartedMachineN = c.Config.GetMinStartedMachineN()
 	r.MaxStartedMachineN = c.Config.GetMaxStartedMachineN()
+	r.Regions = c.Config.Regions
 	r.Interval = c.Config.Interval
 	r.Collectors = collectors
 	r.RegisterPromMetrics(prometheus.DefaultRegisterer)

--- a/cmd/fly-autoscaler/serve.go
+++ b/cmd/fly-autoscaler/serve.go
@@ -55,6 +55,8 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) (err error) {
 
 	// Instantiate and start reconcilation.
 	r := fas.NewReconciler(client)
+	r.MinCreatedMachineN = c.Config.GetMinCreatedMachineN()
+	r.MaxCreatedMachineN = c.Config.GetMaxCreatedMachineN()
 	r.MinStartedMachineN = c.Config.GetMinStartedMachineN()
 	r.MaxStartedMachineN = c.Config.GetMaxStartedMachineN()
 	r.Interval = c.Config.Interval

--- a/etc/fly-autoscaler.yml
+++ b/etc/fly-autoscaler.yml
@@ -1,6 +1,27 @@
 # The name of the target app that you want to scale.
 app-name: "TARGET_APP_NAME"
 
+# A list of regions to create machines in. Regions are chosen via round robin
+# so that machines are evenly distributed.
+# 
+# If this is not specified, the autoscaler will choose a region based on the
+# regions that the app is currently running in.
+regions: ['iad', 'ord', 'sjc']
+
+# This expression determines the number of machines to maintain in your app
+# after each reconciliation. If the number of machines drops below this
+# threshold then more will be created by cloning one of the existing machines.
+# If the number of machines is above this threshold then some machines will be
+# destroyed.
+#
+# There always needs to be at least one machine in your application so the 
+# autoscaler will never destroy your last machine, even if the threshold reaches
+# zero.
+# 
+# You can also define separate minimum & maximum thresholds using the
+# "min_created_machine_count" & "max_created_machine_count" fields.
+created-machine-count: "ceil(queue_depth / 10)"
+
 # This expression determines the number of machines to maintain in a "started"
 # state after each reconciliation. If the number of started machines is less
 # existing machines will be started. If the number of started machines is more

--- a/fas.go
+++ b/fas.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 )
 
 // Expression errors.
@@ -14,8 +15,12 @@ var (
 	ErrExprInf      = errors.New("expression returned Inf")
 )
 
+var _ FlyClient = (*flaps.Client)(nil)
+
 type FlyClient interface {
 	List(ctx context.Context, state string) ([]*fly.Machine, error)
+	Launch(ctx context.Context, input fly.LaunchMachineInput) (*fly.Machine, error)
+	Destroy(ctx context.Context, input fly.RemoveMachineInput, nonce string) error
 	Start(ctx context.Context, id, nonce string) (*fly.MachineStartResponse, error)
 	Stop(ctx context.Context, in fly.StopMachineInput, nonce string) error
 }

--- a/mock/fly_client.go
+++ b/mock/fly_client.go
@@ -10,13 +10,23 @@ import (
 var _ fas.FlyClient = (*FlyClient)(nil)
 
 type FlyClient struct {
-	ListFunc  func(ctx context.Context, state string) ([]*fly.Machine, error)
-	StartFunc func(ctx context.Context, id, nonce string) (*fly.MachineStartResponse, error)
-	StopFunc  func(ctx context.Context, in fly.StopMachineInput, nonce string) error
+	ListFunc    func(ctx context.Context, state string) ([]*fly.Machine, error)
+	LaunchFunc  func(ctx context.Context, input fly.LaunchMachineInput) (*fly.Machine, error)
+	DestroyFunc func(ctx context.Context, input fly.RemoveMachineInput, nonce string) error
+	StartFunc   func(ctx context.Context, id, nonce string) (*fly.MachineStartResponse, error)
+	StopFunc    func(ctx context.Context, in fly.StopMachineInput, nonce string) error
 }
 
 func (c *FlyClient) List(ctx context.Context, state string) ([]*fly.Machine, error) {
 	return c.ListFunc(ctx, state)
+}
+
+func (c *FlyClient) Launch(ctx context.Context, config fly.LaunchMachineInput) (*fly.Machine, error) {
+	return c.LaunchFunc(ctx, config)
+}
+
+func (c *FlyClient) Destroy(ctx context.Context, input fly.RemoveMachineInput, nonce string) error {
+	return c.DestroyFunc(ctx, input, nonce)
 }
 
 func (c *FlyClient) Start(ctx context.Context, id, nonce string) (*fly.MachineStartResponse, error) {

--- a/reconciler.go
+++ b/reconciler.go
@@ -411,7 +411,7 @@ func (r *Reconciler) createMachine(ctx context.Context, config *fly.MachineConfi
 }
 
 func (r *Reconciler) destroyMachine(ctx context.Context, id string) error {
-	if err := r.client.Destroy(ctx, fly.RemoveMachineInput{ID: id}, ""); err != nil {
+	if err := r.client.Destroy(ctx, fly.RemoveMachineInput{ID: id, Kill: true}, ""); err != nil {
 		r.Stats.MachineDestroyFailed.Add(1)
 		return err
 	}

--- a/reconciler_test.go
+++ b/reconciler_test.go
@@ -46,8 +46,10 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	t.Run("Constant", func(t *testing.T) {
 		r := fas.NewReconciler(nil)
 		r.MinStartedMachineN = "1"
-		if v, err := r.CalcMinStartedMachineN(); err != nil {
+		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
+		} else if !ok {
+			t.Fatal("expected ok")
 		} else if got, want := v, 1; got != want {
 			t.Fatalf("MinStartedMachineN=%v, want %v", got, want)
 		}
@@ -56,8 +58,10 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	t.Run("Round", func(t *testing.T) {
 		r := fas.NewReconciler(nil)
 		r.MinStartedMachineN = "2.6"
-		if v, err := r.CalcMinStartedMachineN(); err != nil {
+		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
+		} else if !ok {
+			t.Fatal("expected ok")
 		} else if got, want := v, 3; got != want {
 			t.Fatalf("MinStartedMachineN=%v, want %v", got, want)
 		}
@@ -68,8 +72,10 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 		r.MinStartedMachineN = "x + y + 2"
 		r.SetValue("x", 4)
 		r.SetValue("y", 7)
-		if v, err := r.CalcMinStartedMachineN(); err != nil {
+		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
+		} else if !ok {
+			t.Fatal("expected ok")
 		} else if got, want := v, 13; got != want {
 			t.Fatalf("MinStartedMachineN=%v, want %v", got, want)
 		}
@@ -80,8 +86,10 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 		r.MinStartedMachineN = "min(x, y)"
 		r.SetValue("x", 4)
 		r.SetValue("y", 7)
-		if v, err := r.CalcMinStartedMachineN(); err != nil {
+		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
+		} else if !ok {
+			t.Fatal("expected ok")
 		} else if got, want := v, 4; got != want {
 			t.Fatalf("MinStartedMachineN=%v, want %v", got, want)
 		}
@@ -92,8 +100,10 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 		r.MinStartedMachineN = "max(x, y)"
 		r.SetValue("x", 4)
 		r.SetValue("y", 7)
-		if v, err := r.CalcMinStartedMachineN(); err != nil {
+		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
+		} else if !ok {
+			t.Fatal("expected ok")
 		} else if got, want := v, 7; got != want {
 			t.Fatalf("MinStartedMachineN=%v, want %v", got, want)
 		}
@@ -102,8 +112,22 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	t.Run("Neg", func(t *testing.T) {
 		r := fas.NewReconciler(nil)
 		r.MinStartedMachineN = "-2"
-		if v, err := r.CalcMinStartedMachineN(); err != nil {
+		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
+		} else if !ok {
+			t.Fatal("expected ok")
+		} else if got, want := v, 0; got != want {
+			t.Fatalf("MinStartedMachineN=%v, want %v", got, want)
+		}
+	})
+
+	t.Run("Blank", func(t *testing.T) {
+		r := fas.NewReconciler(nil)
+		r.MinStartedMachineN = ""
+		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
+			t.Fatal(err)
+		} else if ok {
+			t.Fatal("expected not ok")
 		} else if got, want := v, 0; got != want {
 			t.Fatalf("MinStartedMachineN=%v, want %v", got, want)
 		}
@@ -113,7 +137,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 		r := fas.NewReconciler(nil)
 		r.MinStartedMachineN = "x + 1"
 		r.SetValue("x", math.NaN())
-		if _, err := r.CalcMinStartedMachineN(); err == nil || err != fas.ErrExprNaN {
+		if _, _, err := r.CalcMinStartedMachineN(); err == nil || err != fas.ErrExprNaN {
 			t.Fatal(err)
 		}
 	})
@@ -121,40 +145,186 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	t.Run("Inf", func(t *testing.T) {
 		r := fas.NewReconciler(nil)
 		r.MinStartedMachineN = "1 / 0"
-		if _, err := r.CalcMinStartedMachineN(); err == nil || err != fas.ErrExprInf {
+		if _, _, err := r.CalcMinStartedMachineN(); err == nil || err != fas.ErrExprInf {
 			t.Fatal(err)
 		}
 	})
 }
 
-func TestReconciler_Scale(t *testing.T) {
-	// Ensure that if the target count and started count are the same, there
-	// will not be any new machines started.
-	t.Run("NoScale", func(t *testing.T) {
+// Ensure that if the target count and started count are the same, there
+// will not be any new machines started.
+func TestReconciler_Scale_NoScale(t *testing.T) {
+	var client mock.FlyClient
+	client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
+		return []*fly.Machine{
+			{ID: "1", State: fly.MachineStateStarted},
+			{ID: "2", State: fly.MachineStateStopped},
+		}, nil
+	}
+	client.StartFunc = func(ctx context.Context, id, nonce string) (*fly.MachineStartResponse, error) {
+		t.Fatal("expected no start")
+		return &fly.MachineStartResponse{}, nil
+	}
+
+	r := fas.NewReconciler(&client)
+	r.MinStartedMachineN = "1"
+	r.MaxStartedMachineN = "2"
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if got, want := r.Stats.NoScale.Load(), int64(1); got != want {
+		t.Fatalf("NoScale=%v, want %v", got, want)
+	}
+}
+
+func TestReconciler_Scale_Create(t *testing.T) {
+	// Ensure that machines will be created when below the min number.
+	t.Run("OK", func(t *testing.T) {
+		var invokeCreateN int
 		var client mock.FlyClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return []*fly.Machine{
-				{ID: "1", State: fly.MachineStateStarted},
-				{ID: "2", State: fly.MachineStateStopped},
+				{
+					ID:     "1",
+					State:  fly.MachineStateStarted,
+					Region: "iad",
+					Config: &fly.MachineConfig{
+						Metadata: map[string]string{"foo": "bar"},
+					},
+				},
+				{
+					ID:     "2",
+					State:  fly.MachineStateStopped,
+					Region: "den",
+					Config: &fly.MachineConfig{
+						Metadata: map[string]string{"baz": "bat"},
+					},
+				},
 			}, nil
 		}
-		client.StartFunc = func(ctx context.Context, id, nonce string) (*fly.MachineStartResponse, error) {
-			t.Fatal("expected no start")
-			return &fly.MachineStartResponse{}, nil
+		client.LaunchFunc = func(ctx context.Context, input fly.LaunchMachineInput) (*fly.Machine, error) {
+			invokeCreateN++
+
+			// Ensure we are using the first machine's metadata.
+			if got, want := input.Config.Metadata["foo"], "bar"; got != want {
+				t.Fatalf("metadata=%v, want %v", got, want)
+			}
+
+			switch invokeCreateN {
+			case 1:
+				return &fly.Machine{ID: "1", Region: input.Region}, nil
+			case 2:
+				return &fly.Machine{ID: "2", Region: input.Region}, nil
+			default:
+				t.Fatalf("too many 'launch' invocations")
+				return nil, nil
+			}
 		}
 
 		r := fas.NewReconciler(&client)
-		r.MinStartedMachineN = "1"
-		r.MaxStartedMachineN = "2"
+		r.MinCreatedMachineN, r.MaxCreatedMachineN = "4", "4"
 		if err := r.Reconcile(context.Background()); err != nil {
 			t.Fatal(err)
-		} else if got, want := r.Stats.NoScale.Load(), int64(1); got != want {
-			t.Fatalf("NoScale=%v, want %v", got, want)
+		} else if got, want := invokeCreateN, 2; got != want {
+			t.Fatalf("createN=%v, want %v", got, want)
+		}
+		if got, want := r.Stats.BulkCreate.Load(), int64(1); got != want {
+			t.Fatalf("BulkCreate=%v, want %v", got, want)
+		} else if got, want := r.Stats.MachineCreated.Load(), int64(2); got != want {
+			t.Fatalf("MachineCreated=%v, want %v", got, want)
+		} else if got, want := r.Stats.MachineCreateFailed.Load(), int64(0); got != want {
+			t.Fatalf("MachineCreateFailed=%v, want %v", got, want)
 		}
 	})
 
-	// Ensure that number of machines will be scaled up to match target number.
-	t.Run("ScaleUp", func(t *testing.T) {
+	// Ensure that an error occurs when creating a machine with no machine to clone.
+	t.Run("ErrNoMachineAvailable", func(t *testing.T) {
+		var client mock.FlyClient
+		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
+			return []*fly.Machine{}, nil
+		}
+		client.LaunchFunc = func(ctx context.Context, input fly.LaunchMachineInput) (*fly.Machine, error) {
+			return nil, fmt.Errorf("unexpected launch invocation")
+		}
+
+		r := fas.NewReconciler(&client)
+		r.MinCreatedMachineN = "1"
+		if err := r.Reconcile(context.Background()); err == nil || err.Error() != `no machine available to clone for scale up` {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+// Ensure that machines will be destroyed when above the max count.
+func TestReconciler_Scale_Destroy(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		var invokeDestroyN int
+		var client mock.FlyClient
+		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
+			return []*fly.Machine{
+				{ID: "1", State: fly.MachineStateStarted, Region: "iad"},
+				{ID: "2", State: fly.MachineStateStopped, Region: "den"},
+				{ID: "3", State: fly.MachineStateStopped, Region: "iad"},
+				{ID: "4", State: fly.MachineStateStopped, Region: "mad"},
+			}, nil
+		}
+		client.DestroyFunc = func(ctx context.Context, input fly.RemoveMachineInput, nonce string) error {
+			invokeDestroyN++
+			switch input.ID {
+			case "2", "3":
+				// ok
+			default:
+				t.Fatalf("unexpected machine id: %q", input.ID)
+			}
+			return nil
+		}
+
+		r := fas.NewReconciler(&client)
+		r.MinCreatedMachineN, r.MaxCreatedMachineN = "2", "2"
+		if err := r.Reconcile(context.Background()); err != nil {
+			t.Fatal(err)
+		} else if got, want := invokeDestroyN, 2; got != want {
+			t.Fatalf("destroyN=%v, want %v", got, want)
+		}
+		if got, want := r.Stats.BulkDestroy.Load(), int64(1); got != want {
+			t.Fatalf("BulkDestroy=%v, want %v", got, want)
+		} else if got, want := r.Stats.MachineDestroyed.Load(), int64(2); got != want {
+			t.Fatalf("MachineDestroyed=%v, want %v", got, want)
+		} else if got, want := r.Stats.MachineDestroyFailed.Load(), int64(0); got != want {
+			t.Fatalf("MachineDestroyFailed=%v, want %v", got, want)
+		}
+	})
+
+	// Ensure we always leave at least 1 machine available so we can clone for scale up.
+	t.Run("AttemptScaleToZero", func(t *testing.T) {
+		var client mock.FlyClient
+		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
+			return []*fly.Machine{
+				{ID: "1", State: fly.MachineStateStopped, Region: "iad"},
+				{ID: "2", State: fly.MachineStateStopped, Region: "iad"},
+				{ID: "3", State: fly.MachineStateStarted, Region: "iad"},
+				{ID: "4", State: fly.MachineStateCreated, Region: "iad"},
+			}, nil
+		}
+		client.DestroyFunc = func(ctx context.Context, input fly.RemoveMachineInput, nonce string) error {
+			return nil
+		}
+
+		r := fas.NewReconciler(&client)
+		r.MaxCreatedMachineN = "0"
+		if err := r.Reconcile(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := r.Stats.MachineDestroyed.Load(), int64(3); got != want {
+			t.Fatalf("MachineDestroyed=%v, want %v", got, want)
+		} else if got, want := r.Stats.MachineDestroyFailed.Load(), int64(0); got != want {
+			t.Fatalf("MachineDestroyFailed=%v, want %v", got, want)
+		}
+	})
+}
+
+// Ensure that number of machines will be scaled up to match target number.
+func TestReconciler_Scale_Start(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
 		var invokeStartN int
 		var client mock.FlyClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
@@ -183,8 +353,9 @@ func TestReconciler_Scale(t *testing.T) {
 			t.Fatal(err)
 		} else if got, want := invokeStartN, 2; got != want {
 			t.Fatalf("startN=%v, want %v", got, want)
-		} else if got, want := r.Stats.ScaleUp.Load(), int64(1); got != want {
-			t.Fatalf("ScaleUp=%v, want %v", got, want)
+		}
+		if got, want := r.Stats.BulkStart.Load(), int64(1); got != want {
+			t.Fatalf("BulkStart=%v, want %v", got, want)
 		} else if got, want := r.Stats.MachineStarted.Load(), int64(2); got != want {
 			t.Fatalf("MachineStarted=%v, want %v", got, want)
 		} else if got, want := r.Stats.MachineStartFailed.Load(), int64(0); got != want {
@@ -193,7 +364,7 @@ func TestReconciler_Scale(t *testing.T) {
 	})
 
 	// Ensure that the reconciler will keep trying to start machines if one fails.
-	t.Run("StartFailed", func(t *testing.T) {
+	t.Run("Failed", func(t *testing.T) {
 		var invokeStartN int
 		var client mock.FlyClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
@@ -224,17 +395,19 @@ func TestReconciler_Scale(t *testing.T) {
 			t.Fatal(err)
 		} else if got, want := invokeStartN, 3; got != want {
 			t.Fatalf("startN=%v, want %v", got, want)
-		} else if got, want := r.Stats.ScaleUp.Load(), int64(1); got != want {
-			t.Fatalf("ScaleUp=%v, want %v", got, want)
+		} else if got, want := r.Stats.BulkStart.Load(), int64(1); got != want {
+			t.Fatalf("BulkStart=%v, want %v", got, want)
 		} else if got, want := r.Stats.MachineStarted.Load(), int64(2); got != want {
 			t.Fatalf("MachineStarted=%v, want %v", got, want)
 		} else if got, want := r.Stats.MachineStartFailed.Load(), int64(1); got != want {
 			t.Fatalf("MachineStartFailed=%v, want %v", got, want)
 		}
 	})
+}
 
-	// The reconciler should stop machines when they are above the max count.
-	t.Run("ScaleDown", func(t *testing.T) {
+// Ensure the reconciler should stop machines when they are above the max count.
+func TestReconciler_Scale_Stop(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
 		var client mock.FlyClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return []*fly.Machine{
@@ -259,14 +432,14 @@ func TestReconciler_Scale(t *testing.T) {
 		r.MaxStartedMachineN = "1"
 		if err := r.Reconcile(context.Background()); err != nil {
 			t.Fatal(err)
-		} else if got, want := r.Stats.ScaleDown.Load(), int64(1); got != want {
-			t.Fatalf("ScaleDown=%v, want %v", got, want)
+		} else if got, want := r.Stats.BulkStop.Load(), int64(1); got != want {
+			t.Fatalf("BulkStop=%v, want %v", got, want)
 		} else if got, want := r.Stats.MachineStopped.Load(), int64(2); got != want {
 			t.Fatalf("MachineStopped=%v, want %v", got, want)
 		}
 	})
 
-	t.Run("StopFailed", func(t *testing.T) {
+	t.Run("Failed", func(t *testing.T) {
 		var client mock.FlyClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return []*fly.Machine{


### PR DESCRIPTION
This pull request implements autoscaling by creating & destroying Fly Machines. Previously, existing machines could be started or stopped but there was always a fixed pool to scale within. With this change, users can set a single threshold (`created-machine-count`) or a threshold range (`min-created-machine-count` & `max-created-machine-count`) to scale their machines by creating & destroying.

One limitation of this approach is that creation is performed by cloning an existing machine in the app so this scaler does not support scale to zero. You can still scale down your last machine by stopping it by using `max-started-machine-count`.

Fixes https://github.com/superfly/fly-autoscaler/issues/18

## Usage

To enable create/destroy scaling, you can set the related environment variables to an expression representing the desired number of machines:

```
FAS_CREATED_MACHINE_COUNT="queue_count / 10"
```

or specify a range:

```
FAS_MIN_CREATED_MACHINE_COUNT="queue_count / 10 - 1"
FAS_MAX_CREATED_MACHINE_COUNT="queue_count / 10 + 1"
```

or you can specify these in your `fly-autoscaler.yml` file:

```yml
created-machine-count: "queue_count / 10"
```

or 

```yml
min-created-machine-count: "queue_count / 10 - 1"
max-created-machine-count: "queue_count / 10 + 1"
```