### PR TITLE
Implement multi-app scaling

### DIFF
--- a/cmd/fly-autoscaler/eval.go
+++ b/cmd/fly-autoscaler/eval.go
@@ -34,6 +34,7 @@ func (c *EvalCommand) Run(ctx context.Context, args []string) (err error) {
 
 	// Instantiate reconciler and evaluate once.
 	r := fas.NewReconciler()
+	r.AppName = c.Config.AppName
 	r.MinCreatedMachineN = c.Config.GetMinCreatedMachineN()
 	r.MaxCreatedMachineN = c.Config.GetMaxCreatedMachineN()
 	r.MinStartedMachineN = c.Config.GetMinStartedMachineN()

--- a/cmd/fly-autoscaler/eval.go
+++ b/cmd/fly-autoscaler/eval.go
@@ -33,7 +33,7 @@ func (c *EvalCommand) Run(ctx context.Context, args []string) (err error) {
 	}
 
 	// Instantiate reconciler and evaluate once.
-	r := fas.NewReconciler(nil)
+	r := fas.NewReconciler()
 	r.MinCreatedMachineN = c.Config.GetMinCreatedMachineN()
 	r.MaxCreatedMachineN = c.Config.GetMaxCreatedMachineN()
 	r.MinStartedMachineN = c.Config.GetMinStartedMachineN()

--- a/cmd/fly-autoscaler/main.go
+++ b/cmd/fly-autoscaler/main.go
@@ -129,9 +129,10 @@ type Config struct {
 
 func NewConfig() *Config {
 	return &Config{
-		Concurrency: fas.DefaultConcurrency,
-		Interval:    fas.DefaultReconcileInterval,
-		Timeout:     fas.DefaultReconcileTimeout,
+		Concurrency:            fas.DefaultConcurrency,
+		Interval:               fas.DefaultReconcileInterval,
+		Timeout:                fas.DefaultReconcileTimeout,
+		AppListRefreshInterval: fas.DefaultAppListRefreshInterval,
 	}
 }
 

--- a/cmd/fly-autoscaler/main.go
+++ b/cmd/fly-autoscaler/main.go
@@ -28,7 +28,13 @@ var (
 	Commit  = ""
 )
 
+const (
+	APIBaseURL = "https://api.fly.io"
+)
+
 func main() {
+	fly.SetBaseURL(APIBaseURL)
+
 	if err := run(context.Background(), os.Args[1:]); err == flag.ErrHelp {
 		os.Exit(2)
 	} else if err != nil {

--- a/cmd/fly-autoscaler/main.go
+++ b/cmd/fly-autoscaler/main.go
@@ -9,12 +9,14 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"time"
 
 	fas "github.com/superfly/fly-autoscaler"
 	fasprom "github.com/superfly/fly-autoscaler/prometheus"
 	"github.com/superfly/fly-autoscaler/temporal"
+	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/fly-go/tokens"
 	"gopkg.in/yaml.v3"
@@ -106,30 +108,37 @@ func registerConfigPathFlag(fs *flag.FlagSet) *string {
 }
 
 type Config struct {
-	AppName            string        `yaml:"app-name"`
-	Regions            []string      `yaml:"regions"`
-	CreatedMachineN    string        `yaml:"created-machine-count"`
-	MinCreatedMachineN string        `yaml:"min-created-machine-count"`
-	MaxCreatedMachineN string        `yaml:"max-created-machine-count"`
-	StartedMachineN    string        `yaml:"started-machine-count"`
-	MinStartedMachineN string        `yaml:"min-started-machine-count"`
-	MaxStartedMachineN string        `yaml:"max-started-machine-count"`
-	Interval           time.Duration `yaml:"interval"`
-	APIToken           string        `yaml:"api-token"`
-	Verbose            bool          `yaml:"verbose"`
+	AppName                string        `yaml:"app-name"`
+	Org                    string        `yaml:"org"`
+	Regions                []string      `yaml:"regions"`
+	CreatedMachineN        string        `yaml:"created-machine-count"`
+	MinCreatedMachineN     string        `yaml:"min-created-machine-count"`
+	MaxCreatedMachineN     string        `yaml:"max-created-machine-count"`
+	StartedMachineN        string        `yaml:"started-machine-count"`
+	MinStartedMachineN     string        `yaml:"min-started-machine-count"`
+	MaxStartedMachineN     string        `yaml:"max-started-machine-count"`
+	Concurrency            int           `yaml:"concurrency"`
+	Interval               time.Duration `yaml:"interval"`
+	Timeout                time.Duration `yaml:"timeout"`
+	AppListRefreshInterval time.Duration `yaml:"app-list-refresh-interval"`
+	APIToken               string        `yaml:"api-token"`
+	Verbose                bool          `yaml:"verbose"`
 
 	MetricCollectors []*MetricCollectorConfig `yaml:"metric-collectors"`
 }
 
 func NewConfig() *Config {
 	return &Config{
-		Interval: fas.DefaultReconcilerInterval,
+		Concurrency: fas.DefaultConcurrency,
+		Interval:    fas.DefaultReconcileInterval,
+		Timeout:     fas.DefaultReconcileTimeout,
 	}
 }
 
-func NewConfigFromEnv() (*Config, error) {
+func NewConfigFromEnv() (_ *Config, err error) {
 	c := NewConfig()
 	c.AppName = os.Getenv("FAS_APP_NAME")
+	c.Org = os.Getenv("FAS_ORG")
 	c.CreatedMachineN = os.Getenv("FAS_CREATED_MACHINE_COUNT")
 	c.MinCreatedMachineN = os.Getenv("FAS_MIN_CREATED_MACHINE_COUNT")
 	c.MaxCreatedMachineN = os.Getenv("FAS_MAX_CREATED_MACHINE_COUNT")
@@ -142,12 +151,26 @@ func NewConfigFromEnv() (*Config, error) {
 		c.Regions = strings.Split(s, ",")
 	}
 
+	if s := os.Getenv("FAS_CONCURRENCY"); s != "" {
+		if c.Concurrency, err = strconv.Atoi(s); err != nil {
+			return nil, fmt.Errorf("cannot parse FAS_CONCURRENCY as integer: %q", s)
+		}
+	}
+
 	if s := os.Getenv("FAS_INTERVAL"); s != "" {
-		d, err := time.ParseDuration(s)
-		if err != nil {
+		if c.Interval, err = time.ParseDuration(s); err != nil {
 			return nil, fmt.Errorf("cannot parse FAS_INTERVAL as duration: %q", s)
 		}
-		c.Interval = d
+	}
+	if s := os.Getenv("FAS_TIMEOUT"); s != "" {
+		if c.Timeout, err = time.ParseDuration(s); err != nil {
+			return nil, fmt.Errorf("cannot parse FAS_TIMEOUT as duration: %q", s)
+		}
+	}
+	if s := os.Getenv("FAS_APP_LIST_REFRESH_INTERVAL"); s != "" {
+		if c.AppListRefreshInterval, err = time.ParseDuration(s); err != nil {
+			return nil, fmt.Errorf("cannot parse FAS_APP_LIST_REFRESH_INTERVAL as duration: %q", s)
+		}
 	}
 
 	if addr := os.Getenv("FAS_PROMETHEUS_ADDRESS"); addr != "" {
@@ -278,15 +301,28 @@ func (c *Config) validateStartedMachineCount() error {
 	return nil
 }
 
-func (c *Config) NewFlapsClient(ctx context.Context) (*flaps.Client, error) {
+func (c *Config) NewFlyClient(ctx context.Context) (*fly.Client, error) {
 	if c.APIToken == "" {
 		return nil, fmt.Errorf("api token required")
 	}
 
-	return flaps.NewWithOptions(ctx, flaps.NewClientOpts{
-		AppName: c.AppName,
-		Tokens:  tokens.Parse(c.APIToken),
-	})
+	return fly.NewClientFromOptions(fly.ClientOptions{
+		Tokens: tokens.Parse(c.APIToken),
+	}), nil
+}
+
+func (c *Config) NewFlapsClient() (fas.NewFlapsClientFunc, error) {
+	if c.APIToken == "" {
+		return nil, fmt.Errorf("api token required")
+	}
+	tok := tokens.Parse(c.APIToken)
+
+	return func(ctx context.Context, appName string) (fas.FlapsClient, error) {
+		return flaps.NewWithOptions(ctx, flaps.NewClientOpts{
+			AppName: appName,
+			Tokens:  tok,
+		})
+	}, nil
 }
 
 func (c *Config) NewMetricCollectors() ([]fas.MetricCollector, error) {

--- a/cmd/fly-autoscaler/serve.go
+++ b/cmd/fly-autoscaler/serve.go
@@ -88,9 +88,9 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) (err error) {
 	c.pool = p
 
 	attrs := []any{
-		slog.Duration("interval", p.ReconcileInterval),
-		slog.Duration("timeout", p.ReconcileTimeout),
-		slog.Duration("appListRefreshInterval", p.AppListRefreshInterval),
+		slog.String("interval", p.ReconcileInterval.String()),
+		slog.String("timeout", p.ReconcileTimeout.String()),
+		slog.String("appListRefreshInterval", p.AppListRefreshInterval.String()),
 		slog.Int("collectors", len(collectors)),
 	}
 

--- a/fas.go
+++ b/fas.go
@@ -15,6 +15,13 @@ var (
 	ErrExprInf      = errors.New("expression returned Inf")
 )
 
+var _ FlyClient = (*fly.Client)(nil)
+
+type FlyClient interface {
+	GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error)
+	GetAppsForOrganization(ctx context.Context, orgID string) ([]fly.App, error)
+}
+
 var _ FlapsClient = (*flaps.Client)(nil)
 
 type FlapsClient interface {
@@ -24,3 +31,5 @@ type FlapsClient interface {
 	Start(ctx context.Context, id, nonce string) (*fly.MachineStartResponse, error)
 	Stop(ctx context.Context, in fly.StopMachineInput, nonce string) error
 }
+
+type NewFlapsClientFunc func(ctx context.Context, appName string) (FlapsClient, error)

--- a/fas.go
+++ b/fas.go
@@ -15,9 +15,9 @@ var (
 	ErrExprInf      = errors.New("expression returned Inf")
 )
 
-var _ FlyClient = (*flaps.Client)(nil)
+var _ FlapsClient = (*flaps.Client)(nil)
 
-type FlyClient interface {
+type FlapsClient interface {
 	List(ctx context.Context, state string) ([]*fly.Machine, error)
 	Launch(ctx context.Context, input fly.LaunchMachineInput) (*fly.Machine, error)
 	Destroy(ctx context.Context, input fly.RemoveMachineInput, nonce string) error

--- a/metric_collector.go
+++ b/metric_collector.go
@@ -1,9 +1,24 @@
 package fas
 
-import "context"
+import (
+	"context"
+	"os"
+)
 
 // MetricCollector represents a client for collecting metrics from an external source.
 type MetricCollector interface {
 	Name() string
-	CollectMetric(ctx context.Context) (float64, error)
+	CollectMetric(ctx context.Context, app string) (float64, error)
+}
+
+// ExpandMetricQuery replaces variables in query with their values.
+func ExpandMetricQuery(ctx context.Context, query, app string) string {
+	return os.Expand(query, func(key string) string {
+		switch key {
+		case "APP_NAME":
+			return app
+		default:
+			return ""
+		}
+	})
 }

--- a/metric_collector_test.go
+++ b/metric_collector_test.go
@@ -1,0 +1,31 @@
+package fas_test
+
+import (
+	"context"
+	"testing"
+
+	fas "github.com/superfly/fly-autoscaler"
+)
+
+func TestExpandMetricQuery(t *testing.T) {
+	t.Run("Static", func(t *testing.T) {
+		result := fas.ExpandMetricQuery(context.Background(), "foo", "my-app")
+		if got, want := result, `foo`; got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Bare", func(t *testing.T) {
+		result := fas.ExpandMetricQuery(context.Background(), "foo $APP_NAME bar", "my-app")
+		if got, want := result, `foo my-app bar`; got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Wrapped", func(t *testing.T) {
+		result := fas.ExpandMetricQuery(context.Background(), "foo${APP_NAME}bar", "my-app")
+		if got, want := result, `foomy-appbar`; got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+}

--- a/mock/flaps_client.go
+++ b/mock/flaps_client.go
@@ -7,9 +7,9 @@ import (
 	"github.com/superfly/fly-go"
 )
 
-var _ fas.FlyClient = (*FlyClient)(nil)
+var _ fas.FlapsClient = (*FlapsClient)(nil)
 
-type FlyClient struct {
+type FlapsClient struct {
 	ListFunc    func(ctx context.Context, state string) ([]*fly.Machine, error)
 	LaunchFunc  func(ctx context.Context, input fly.LaunchMachineInput) (*fly.Machine, error)
 	DestroyFunc func(ctx context.Context, input fly.RemoveMachineInput, nonce string) error
@@ -17,22 +17,22 @@ type FlyClient struct {
 	StopFunc    func(ctx context.Context, in fly.StopMachineInput, nonce string) error
 }
 
-func (c *FlyClient) List(ctx context.Context, state string) ([]*fly.Machine, error) {
+func (c *FlapsClient) List(ctx context.Context, state string) ([]*fly.Machine, error) {
 	return c.ListFunc(ctx, state)
 }
 
-func (c *FlyClient) Launch(ctx context.Context, config fly.LaunchMachineInput) (*fly.Machine, error) {
+func (c *FlapsClient) Launch(ctx context.Context, config fly.LaunchMachineInput) (*fly.Machine, error) {
 	return c.LaunchFunc(ctx, config)
 }
 
-func (c *FlyClient) Destroy(ctx context.Context, input fly.RemoveMachineInput, nonce string) error {
+func (c *FlapsClient) Destroy(ctx context.Context, input fly.RemoveMachineInput, nonce string) error {
 	return c.DestroyFunc(ctx, input, nonce)
 }
 
-func (c *FlyClient) Start(ctx context.Context, id, nonce string) (*fly.MachineStartResponse, error) {
+func (c *FlapsClient) Start(ctx context.Context, id, nonce string) (*fly.MachineStartResponse, error) {
 	return c.StartFunc(ctx, id, nonce)
 }
 
-func (c *FlyClient) Stop(ctx context.Context, in fly.StopMachineInput, nonce string) error {
+func (c *FlapsClient) Stop(ctx context.Context, in fly.StopMachineInput, nonce string) error {
 	return c.StopFunc(ctx, in, nonce)
 }

--- a/mock/fly_client.go
+++ b/mock/fly_client.go
@@ -1,0 +1,23 @@
+package mock
+
+import (
+	"context"
+
+	fas "github.com/superfly/fly-autoscaler"
+	"github.com/superfly/fly-go"
+)
+
+var _ fas.FlyClient = (*FlyClient)(nil)
+
+type FlyClient struct {
+	GetOrganizationBySlugFunc  func(ctx context.Context, slug string) (*fly.Organization, error)
+	GetAppsForOrganizationFunc func(ctx context.Context, orgID string) ([]fly.App, error)
+}
+
+func (m *FlyClient) GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error) {
+	return m.GetOrganizationBySlugFunc(ctx, slug)
+}
+
+func (m *FlyClient) GetAppsForOrganization(ctx context.Context, orgID string) ([]fly.App, error) {
+	return m.GetAppsForOrganizationFunc(ctx, orgID)
+}

--- a/mock/metric_collector.go
+++ b/mock/metric_collector.go
@@ -10,7 +10,7 @@ var _ fas.MetricCollector = (*MetricCollector)(nil)
 
 type MetricCollector struct {
 	name              string
-	CollectMetricFunc func(ctx context.Context) (float64, error)
+	CollectMetricFunc func(ctx context.Context, app string) (float64, error)
 }
 
 func NewMetricCollector(name string) *MetricCollector {
@@ -19,6 +19,6 @@ func NewMetricCollector(name string) *MetricCollector {
 
 func (c *MetricCollector) Name() string { return c.name }
 
-func (c *MetricCollector) CollectMetric(ctx context.Context) (float64, error) {
-	return c.CollectMetricFunc(ctx)
+func (c *MetricCollector) CollectMetric(ctx context.Context, app string) (float64, error) {
+	return c.CollectMetricFunc(ctx, app)
 }

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -42,8 +42,10 @@ func (c *MetricCollector) Name() string {
 	return c.name
 }
 
-func (c *MetricCollector) CollectMetric(ctx context.Context) (float64, error) {
-	result, warnings, err := c.api.Query(context.Background(), c.query, time.Now())
+func (c *MetricCollector) CollectMetric(ctx context.Context, app string) (float64, error) {
+	query := fas.ExpandMetricQuery(ctx, c.query, app)
+
+	result, warnings, err := c.api.Query(context.Background(), query, time.Now())
 	if err != nil {
 		return 0, err
 	} else if len(warnings) > 0 {

--- a/reconciler.go
+++ b/reconciler.go
@@ -21,6 +21,9 @@ type Reconciler struct {
 	// Client to connect to Machines API to scale app. Required.
 	Client FlapsClient
 
+	// The name of the app currently being reconciled.
+	AppName string
+
 	// List of regions that machines can be created in.
 	// The reconciler uses a round-robin approach to choosing next region.
 	Regions []string
@@ -79,7 +82,7 @@ func (r *Reconciler) CollectMetrics(ctx context.Context) error {
 	r.metrics = make(map[string]float64)
 
 	for _, c := range r.Collectors {
-		value, err := c.CollectMetric(ctx)
+		value, err := c.CollectMetric(ctx, r.AppName)
 		if err != nil {
 			return fmt.Errorf("collect metric (%q): %w", c.Name(), err)
 		}

--- a/reconciler.go
+++ b/reconciler.go
@@ -24,7 +24,7 @@ const (
 // Reconciler represents the central part of the autoscaler that stores metrics,
 // computes the number of necessary machines, and performs scaling.
 type Reconciler struct {
-	client    FlyClient
+	client    FlapsClient
 	metrics   map[string]float64
 	regionSeq atomic.Int64
 
@@ -75,7 +75,7 @@ type Reconciler struct {
 	}
 }
 
-func NewReconciler(client FlyClient) *Reconciler {
+func NewReconciler(client FlapsClient) *Reconciler {
 	r := &Reconciler{
 		client:   client,
 		metrics:  make(map[string]float64),

--- a/reconciler_pool.go
+++ b/reconciler_pool.go
@@ -278,6 +278,7 @@ func (p *ReconcilerPool) monitorReconciler(ctx context.Context, r *Reconciler) {
 			ctx, cancel := context.WithTimeoutCause(p.ctx, p.ReconcileTimeout, errReconciliationTimeout)
 			defer cancel()
 
+			r.AppName = info.name
 			r.Client = info.client
 
 			if err := r.CollectMetrics(ctx); err != nil {

--- a/reconciler_pool.go
+++ b/reconciler_pool.go
@@ -285,14 +285,14 @@ func (p *ReconcilerPool) monitorReconciler(ctx context.Context, r *Reconciler) {
 				slog.Error("metrics collection failed",
 					slog.String("app", info.name),
 					slog.Any("err", err))
-				return
+				continue
 			}
 
 			if err := r.Reconcile(ctx); err != nil {
 				slog.Error("reconciliation failed",
 					slog.String("app", info.name),
 					slog.Any("err", err))
-				return
+				continue
 			}
 
 		}

--- a/reconciler_pool.go
+++ b/reconciler_pool.go
@@ -1,0 +1,407 @@
+package fas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	DefaultConcurrency            = 1
+	DefaultReconcileTimeout       = 30 * time.Second
+	DefaultReconcileInterval      = 15 * time.Second
+	DefaultAppListRefreshInterval = 60 * time.Second
+)
+
+// ReconcilerPool represents a set of reconcilers that act as a worker pool.
+//
+// This is used to distribute scaling across multiple applications while also
+// limiting the maximum concurrency allowed by the scaler.
+type ReconcilerPool struct {
+	flyClient   FlyClient
+	reconcilers []*Reconciler
+
+	wg     sync.WaitGroup
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+
+	ch    chan appInfo // work queue
+	orgID string       // cached organization id
+	apps  struct {
+		sync.Mutex
+		m map[string]appInfo
+	}
+
+	// Time allowed to perform reconciliation for a single app.
+	ReconcileTimeout time.Duration
+
+	// Frequency to run the reconciliation loop for each app.
+	ReconcileInterval time.Duration
+
+	// Frequency to update the list of matching apps when using wildcards.
+	AppListRefreshInterval time.Duration
+
+	// Name of application to scale. Supports wildcards for multiple apps.
+	// All applications must be in the same org.
+	AppName string
+
+	// Organization slug. Required if app name is a wildcard.
+	OrganizationSlug string
+
+	// NewFlapsClient is a constructor for building a FLAPS client for a given app.
+	NewFlapsClient NewFlapsClientFunc
+
+	// NewReconciler is a constructor for building reconcilers.
+	// Called one or more times on Open().
+	NewReconciler func() *Reconciler
+
+	// Shared stats for all reconcilers.
+	Stats ReconcilerStats
+}
+
+// NewReconcilerPool returns a new instance of ReconcilerPool.
+func NewReconcilerPool(flyClient FlyClient, concurrency int) *ReconcilerPool {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	p := &ReconcilerPool{
+		flyClient:   flyClient,
+		reconcilers: make([]*Reconciler, concurrency),
+		ch:          make(chan appInfo),
+
+		ReconcileTimeout:       DefaultReconcileTimeout,
+		ReconcileInterval:      DefaultReconcileInterval,
+		AppListRefreshInterval: DefaultAppListRefreshInterval,
+	}
+	p.ctx, p.cancel = context.WithCancelCause(context.Background())
+	p.apps.m = make(map[string]appInfo)
+
+	return p
+}
+
+func (p *ReconcilerPool) Open() error {
+	if p.AppName == "" {
+		return fmt.Errorf("app name required")
+	}
+	if p.NewFlapsClient == nil {
+		return fmt.Errorf("flaps client constructor required")
+	}
+
+	// Instantiate reconcilers.
+	for i := range p.reconcilers {
+		r := p.NewReconciler()
+		r.Stats = &p.Stats // share the same stats object
+		p.reconcilers[i] = r
+	}
+
+	// Limit concurrency to 1 if we only have a single app to manage.
+	appNameHasWildcard := strings.Contains(p.AppName, "*")
+	if !appNameHasWildcard {
+		p.reconcilers = []*Reconciler{p.reconcilers[0]}
+	}
+
+	// We need the organization slug to fetch the list of app names so
+	// ensure we have it if the app name uses a wildcard.
+	if appNameHasWildcard && p.OrganizationSlug == "" {
+		return fmt.Errorf("organization required if app name uses a wildcard")
+	}
+
+	// Start each reconciler in a separate goroutine and wait for work.
+	p.wg.Add(len(p.reconcilers))
+	for _, r := range p.reconcilers {
+		r := r
+		go func() { defer p.wg.Done(); p.monitorReconciler(p.ctx, r) }()
+	}
+
+	// If the app name does not contain a wildcard, set it as the value list
+	// and have it push
+	if !appNameHasWildcard {
+		client, err := p.NewFlapsClient(context.Background(), p.AppName)
+		if err != nil {
+			return fmt.Errorf("cannot initialize flaps client: %w", err)
+		}
+		p.apps.m[p.AppName] = appInfo{
+			name:   p.AppName,
+			client: client,
+		}
+
+		p.wg.Add(1)
+		go func() { defer p.wg.Done(); p.monitorWorkQueueGenerator(p.ctx) }()
+	} else {
+		// If there is wildcard then we need to kick off the app list monitor
+		// first. Once we have a set of app names then we can kick off the
+		// work queue.
+		p.wg.Add(1)
+		go func() { defer p.wg.Done(); p.monitorAppNameRefresh(p.ctx) }()
+	}
+
+	return nil
+}
+
+// Close stops all processing of the pool and underlying reconcilers.
+// Only returns once all reconcilers have finished processing.
+func (p *ReconcilerPool) Close() error {
+	p.cancel(errReconcilerPoolClosing)
+	p.wg.Wait()
+	return nil
+}
+
+// monitorWorkQueueGenerator pushes all apps into the work queue on an interval.
+func (p *ReconcilerPool) monitorWorkQueueGenerator(ctx context.Context) {
+	ticker := time.NewTicker(p.ReconcileInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Fetch the app list under lock.
+			p.apps.Lock()
+			m := p.apps.m
+			p.apps.Unlock()
+
+			// Push all app names into the work queue.
+			for _, info := range m {
+				select {
+				case <-ctx.Done():
+					return
+				case p.ch <- info:
+				}
+			}
+		}
+	}
+}
+
+// monitorAppNameRefresh runs in the background and periodically refreshes the
+// list of apps to monitor. This will kick off another goroutine to push the
+// current list of names into the work queue once obtained.
+func (p *ReconcilerPool) monitorAppNameRefresh(ctx context.Context) {
+	ticker := time.NewTicker(p.AppListRefreshInterval)
+	defer ticker.Stop()
+
+	var initialized bool
+	for {
+		if err := p.updateAppNameList(ctx); err != nil {
+			slog.Error("app list update failed", slog.Any("err", err))
+		}
+
+		// Start the work generator once we have our initial list.
+		if !initialized {
+			initialized = true
+			p.wg.Add(1)
+			go func() { defer p.wg.Done(); p.monitorWorkQueueGenerator(p.ctx) }()
+		}
+
+		// Wait for the next time we fetch the app name list.
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (p *ReconcilerPool) updateAppNameList(ctx context.Context) error {
+	// Compile the wildcard expression as a regex so we can use it to match.
+	re, err := regexp.Compile(FormatWildcardAsRegexp(p.AppName))
+	if err != nil {
+		return fmt.Errorf("compile wildcard as regexp: %w", err)
+	}
+
+	// Fetch and cache the organization ID.
+	if p.orgID == "" {
+		org, err := p.flyClient.GetOrganizationBySlug(ctx, p.OrganizationSlug)
+		if err != nil {
+			return fmt.Errorf("get organization by slug: %w", err)
+		}
+		p.orgID = org.ID
+	}
+
+	apps, err := p.flyClient.GetAppsForOrganization(ctx, p.orgID)
+	if err != nil {
+		return fmt.Errorf("get apps for organization: %w", err)
+	}
+
+	p.apps.Lock()
+	defer p.apps.Unlock()
+
+	m := make(map[string]appInfo)
+	for i := range apps {
+		name := apps[i].Name
+
+		// Match against wildcard expression.
+		if !re.MatchString(name) {
+			continue
+		}
+
+		// Reuse client, if possible.
+		if info, ok := p.apps.m[name]; ok {
+			m[name] = info
+			continue
+		}
+
+		// Otherwise build a new client with our constructor.
+		client, err := p.NewFlapsClient(ctx, name)
+		if err != nil {
+			return fmt.Errorf("cannot build flaps client for app %q: %w", name, err)
+		}
+		m[name] = appInfo{
+			name:   name,
+			client: client,
+		}
+	}
+
+	// Replace entire map so we
+	p.apps.m = m
+
+	return nil
+}
+
+// monitorReconciler monitors the work queue and passes apps to the reconciler.
+func (p *ReconcilerPool) monitorReconciler(ctx context.Context, r *Reconciler) {
+	errReconciliationTimeout := fmt.Errorf("reconciliation timeout")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case info := <-p.ch:
+			ctx, cancel := context.WithTimeoutCause(p.ctx, p.ReconcileTimeout, errReconciliationTimeout)
+			defer cancel()
+
+			r.Client = info.client
+
+			if err := r.CollectMetrics(ctx); err != nil {
+				slog.Error("metrics collection failed",
+					slog.String("app", info.name),
+					slog.Any("err", err))
+				return
+			}
+
+			if err := r.Reconcile(ctx); err != nil {
+				slog.Error("reconciliation failed",
+					slog.String("app", info.name),
+					slog.Any("err", err))
+				return
+			}
+
+		}
+	}
+}
+
+func (p *ReconcilerPool) RegisterPromMetrics(reg prometheus.Registerer) {
+	p.registerMachineStartCount(reg)
+	p.registerMachineStoppedCount(reg)
+	p.registerReconcileCount(reg)
+}
+
+func (p *ReconcilerPool) registerMachineStartCount(reg prometheus.Registerer) {
+	const name = "fas_machine_start_count"
+
+	reg.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Name:        name,
+			ConstLabels: prometheus.Labels{"status": "ok"},
+		},
+		func() float64 { return float64(p.Stats.MachineStarted.Load()) },
+	))
+	reg.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Name:        name,
+			ConstLabels: prometheus.Labels{"status": "failed"},
+		},
+		func() float64 { return float64(p.Stats.MachineStartFailed.Load()) },
+	))
+}
+
+func (p *ReconcilerPool) registerMachineStoppedCount(reg prometheus.Registerer) {
+	const name = "fas_machine_stop_count"
+
+	reg.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Name:        name,
+			ConstLabels: prometheus.Labels{"status": "ok"},
+		},
+		func() float64 { return float64(p.Stats.MachineStopped.Load()) },
+	))
+	reg.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Name:        name,
+			ConstLabels: prometheus.Labels{"status": "failed"},
+		},
+		func() float64 { return float64(p.Stats.MachineStopFailed.Load()) },
+	))
+}
+
+func (p *ReconcilerPool) registerReconcileCount(reg prometheus.Registerer) {
+	const name = "fas_reconcile_count"
+
+	reg.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Name:        name,
+			ConstLabels: prometheus.Labels{"status": "create"},
+		},
+		func() float64 { return float64(p.Stats.BulkCreate.Load()) },
+	))
+
+	reg.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Name:        name,
+			ConstLabels: prometheus.Labels{"status": "destroy"},
+		},
+		func() float64 { return float64(p.Stats.BulkDestroy.Load()) },
+	))
+
+	reg.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Name:        name,
+			ConstLabels: prometheus.Labels{"status": "start"},
+		},
+		func() float64 { return float64(p.Stats.BulkStart.Load()) },
+	))
+
+	reg.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Name:        name,
+			ConstLabels: prometheus.Labels{"status": "stop"},
+		},
+		func() float64 { return float64(p.Stats.BulkStop.Load()) },
+	))
+
+	reg.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{
+			Name:        name,
+			ConstLabels: prometheus.Labels{"status": "no_scale"},
+		},
+		func() float64 { return float64(p.Stats.NoScale.Load()) },
+	))
+}
+
+type appInfo struct {
+	name   string
+	client FlapsClient
+}
+
+// FormatWildcardAsRegexp returns a regexp for a given wildcard expression.
+func FormatWildcardAsRegexp(s string) string {
+	if s == "" {
+		return ".*"
+	}
+
+	a := strings.Split(s, "*")
+	for i := range a {
+		a[i] = regexp.QuoteMeta(a[i])
+	}
+	return "^" + strings.Join(a, ".*") + "$"
+}
+
+var errReconcilerPoolClosing = errors.New("reconciler pool closing")

--- a/reconciler_pool_test.go
+++ b/reconciler_pool_test.go
@@ -113,7 +113,7 @@ func TestReconcilerPool_Run_SingleApp(t *testing.T) {
 	// Collector will simply mirror the target value.
 	var target atomic.Int64
 	collector := mock.NewMetricCollector("target")
-	collector.CollectMetricFunc = func(ctx context.Context) (float64, error) {
+	collector.CollectMetricFunc = func(ctx context.Context, app string) (float64, error) {
 		return float64(target.Load()), nil
 	}
 

--- a/reconciler_pool_test.go
+++ b/reconciler_pool_test.go
@@ -1,0 +1,182 @@
+package fas_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	fas "github.com/superfly/fly-autoscaler"
+	"github.com/superfly/fly-autoscaler/mock"
+	fly "github.com/superfly/fly-go"
+)
+
+func TestFormatWildcardAsRegexp(t *testing.T) {
+	for _, tt := range []struct {
+		in, out string
+	}{
+		{"", ".*"},                        // match all
+		{"*", "^.*$"},                     // match all
+		{"my-app", "^my-app$"},            // exact match
+		{"my-app-*", "^my-app-.*$"},       // suffix match
+		{"my-*-app", "^my-.*-app$"},       // infix match
+		{"*-my-app", "^.*-my-app$"},       // prefix match
+		{"my-[app]*", "^my-\\[app\\].*$"}, // escaped characters
+	} {
+		t.Run("", func(t *testing.T) {
+			if got, want := fas.FormatWildcardAsRegexp(tt.in), tt.out; got != want {
+				t.Fatalf("got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// Ensure prometheus registration does not blow up.
+func TestReconcilerPool_RegisterPromMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	fas.NewReconcilerPool(nil, 1).RegisterPromMetrics(reg)
+	if _, err := reg.Gather(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcilerPool_Run_SingleApp(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short mode enabled, skipping")
+	}
+
+	var mu sync.Mutex
+	machines := []*fly.Machine{
+		{ID: "1", State: fly.MachineStateStopped},
+		{ID: "2", State: fly.MachineStateStopped},
+		{ID: "3", State: fly.MachineStateStopped},
+		{ID: "4", State: fly.MachineStateStopped},
+	}
+
+	machinesByID := make(map[string]*fly.Machine)
+	for _, m := range machines {
+		machinesByID[m.ID] = m
+	}
+
+	var flyClient mock.FlyClient
+	flyClient.GetOrganizationBySlugFunc = func(ctx context.Context, slug string) (*fly.Organization, error) {
+		if got, want := slug, "myorg"; got != want {
+			t.Fatalf("slug=%q, want %q", got, want)
+		}
+		return &fly.Organization{ID: "123"}, nil
+	}
+	flyClient.GetAppsForOrganizationFunc = func(ctx context.Context, orgID string) ([]fly.App, error) {
+		if got, want := orgID, "123"; got != want {
+			t.Fatalf("id=%q, want %q", got, want)
+		}
+		return []fly.App{
+			{Name: "other-app"},
+			{Name: "my-app-1"},
+		}, nil
+	}
+
+	// Client operates on the in-memory list of machines above.
+	var flapsClient mock.FlapsClient
+	flapsClient.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return machines, nil
+	}
+	flapsClient.StartFunc = func(ctx context.Context, id, nonce string) (*fly.MachineStartResponse, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		m := machinesByID[id]
+		if m.State != fly.MachineStateStopped {
+			return nil, fmt.Errorf("unexpected state: %q", m.State)
+		}
+
+		m.State = fly.MachineStateStarted
+		return &fly.MachineStartResponse{}, nil
+	}
+	flapsClient.StopFunc = func(ctx context.Context, in fly.StopMachineInput, nonce string) error {
+		mu.Lock()
+		defer mu.Unlock()
+
+		m := machinesByID[in.ID]
+		if m.State != fly.MachineStateStarted {
+			return fmt.Errorf("unexpected state: %q", m.State)
+		}
+
+		m.State = fly.MachineStateStopped
+		return nil
+	}
+
+	// Collector will simply mirror the target value.
+	var target atomic.Int64
+	collector := mock.NewMetricCollector("target")
+	collector.CollectMetricFunc = func(ctx context.Context) (float64, error) {
+		return float64(target.Load()), nil
+	}
+
+	p := fas.NewReconcilerPool(&flyClient, 1)
+	p.OrganizationSlug = "myorg"
+	p.AppName = "my-app-*"
+	p.ReconcileInterval = 100 * time.Millisecond
+	p.NewReconciler = func() *fas.Reconciler {
+		r := fas.NewReconciler()
+		r.Client = &flapsClient
+		r.MinStartedMachineN = "target"
+		r.MaxStartedMachineN = r.MinStartedMachineN
+		r.Collectors = []fas.MetricCollector{collector}
+		return r
+	}
+	p.NewFlapsClient = func(ctx context.Context, name string) (fas.FlapsClient, error) {
+		return &flapsClient, nil
+	}
+	if err := p.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Close() }()
+
+	waitInterval := 5 * p.ReconcileInterval
+
+	// Ensure no machines are started.
+	time.Sleep(waitInterval)
+	if got, want := machineCountByState(machines, fly.MachineStateStarted), 0; got != want {
+		t.Fatalf("started=%v, want %v", got, want)
+	}
+
+	t.Log("Increase target count...")
+	target.Store(2)
+	time.Sleep(waitInterval)
+	if got, want := machineCountByState(machines, fly.MachineStateStarted), 2; got != want {
+		t.Fatalf("started=%v, want %v", got, want)
+	}
+
+	t.Log("Increase target count to max...")
+	target.Store(4)
+	time.Sleep(waitInterval)
+	if got, want := machineCountByState(machines, fly.MachineStateStarted), 4; got != want {
+		t.Fatalf("started=%v, want %v", got, want)
+	}
+
+	t.Log("Exceed total machine count...")
+	target.Store(10)
+	time.Sleep(waitInterval)
+	if got, want := machineCountByState(machines, fly.MachineStateStarted), 4; got != want {
+		t.Fatalf("started=%v, want %v", got, want)
+	}
+
+	t.Log("Downscale to zero...")
+	target.Store(0)
+	time.Sleep(waitInterval)
+	if got, want := machineCountByState(machines, fly.MachineStateStarted), 0; got != want {
+		t.Fatalf("started=%v, want %v", got, want)
+	}
+
+	t.Log("Closing pool")
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Test complete")
+}

--- a/reconciler_test.go
+++ b/reconciler_test.go
@@ -154,7 +154,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 // Ensure that if the target count and started count are the same, there
 // will not be any new machines started.
 func TestReconciler_Scale_NoScale(t *testing.T) {
-	var client mock.FlyClient
+	var client mock.FlapsClient
 	client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 		return []*fly.Machine{
 			{ID: "1", State: fly.MachineStateStarted},
@@ -180,7 +180,7 @@ func TestReconciler_Scale_Create(t *testing.T) {
 	// Ensure that machines will be created when below the min number.
 	t.Run("OK", func(t *testing.T) {
 		var invokeCreateN int
-		var client mock.FlyClient
+		var client mock.FlapsClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return []*fly.Machine{
 				{
@@ -238,7 +238,7 @@ func TestReconciler_Scale_Create(t *testing.T) {
 
 	// Ensure that an error occurs when creating a machine with no machine to clone.
 	t.Run("ErrNoMachineAvailable", func(t *testing.T) {
-		var client mock.FlyClient
+		var client mock.FlapsClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return []*fly.Machine{}, nil
 		}
@@ -258,7 +258,7 @@ func TestReconciler_Scale_Create(t *testing.T) {
 func TestReconciler_Scale_Destroy(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		var invokeDestroyN int
-		var client mock.FlyClient
+		var client mock.FlapsClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return []*fly.Machine{
 				{ID: "1", State: fly.MachineStateStarted, Region: "iad"},
@@ -296,7 +296,7 @@ func TestReconciler_Scale_Destroy(t *testing.T) {
 
 	// Ensure we always leave at least 1 machine available so we can clone for scale up.
 	t.Run("AttemptScaleToZero", func(t *testing.T) {
-		var client mock.FlyClient
+		var client mock.FlapsClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return []*fly.Machine{
 				{ID: "1", State: fly.MachineStateStopped, Region: "iad"},
@@ -326,7 +326,7 @@ func TestReconciler_Scale_Destroy(t *testing.T) {
 func TestReconciler_Scale_Start(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		var invokeStartN int
-		var client mock.FlyClient
+		var client mock.FlapsClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return []*fly.Machine{
 				{ID: "1", State: fly.MachineStateStarted},
@@ -366,7 +366,7 @@ func TestReconciler_Scale_Start(t *testing.T) {
 	// Ensure that the reconciler will keep trying to start machines if one fails.
 	t.Run("Failed", func(t *testing.T) {
 		var invokeStartN int
-		var client mock.FlyClient
+		var client mock.FlapsClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return []*fly.Machine{
 				{ID: "1", State: fly.MachineStateStopped},
@@ -408,7 +408,7 @@ func TestReconciler_Scale_Start(t *testing.T) {
 // Ensure the reconciler should stop machines when they are above the max count.
 func TestReconciler_Scale_Stop(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
-		var client mock.FlyClient
+		var client mock.FlapsClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return []*fly.Machine{
 				{ID: "1", State: fly.MachineStateStarted},
@@ -440,7 +440,7 @@ func TestReconciler_Scale_Stop(t *testing.T) {
 	})
 
 	t.Run("Failed", func(t *testing.T) {
-		var client mock.FlyClient
+		var client mock.FlapsClient
 		client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return []*fly.Machine{
 				{ID: "1", State: fly.MachineStateStarted},
@@ -503,7 +503,7 @@ func TestReconciler_StartStop(t *testing.T) {
 	}
 
 	// Client operates on the in-memory list of machines above.
-	var client mock.FlyClient
+	var client mock.FlapsClient
 	client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
 		mu.Lock()
 		defer mu.Unlock()

--- a/reconciler_test.go
+++ b/reconciler_test.go
@@ -6,12 +6,8 @@ import (
 	"log/slog"
 	"math"
 	"os"
-	"sync"
-	"sync/atomic"
 	"testing"
-	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	fas "github.com/superfly/fly-autoscaler"
 	"github.com/superfly/fly-autoscaler/mock"
 	"github.com/superfly/fly-go"
@@ -25,7 +21,7 @@ func init() {
 
 func TestReconciler_Value(t *testing.T) {
 	t.Run("SetValue", func(t *testing.T) {
-		r := fas.NewReconciler(nil)
+		r := fas.NewReconciler()
 		r.SetValue("foo", 100)
 		if v, ok := r.Value("foo"); !ok {
 			t.Fatal("expected value")
@@ -35,7 +31,7 @@ func TestReconciler_Value(t *testing.T) {
 	})
 
 	t.Run("NoValue", func(t *testing.T) {
-		r := fas.NewReconciler(nil)
+		r := fas.NewReconciler()
 		if _, ok := r.Value("foo"); ok {
 			t.Fatal("expected no value")
 		}
@@ -44,7 +40,7 @@ func TestReconciler_Value(t *testing.T) {
 
 func TestReconciler_MinStartedMachineN(t *testing.T) {
 	t.Run("Constant", func(t *testing.T) {
-		r := fas.NewReconciler(nil)
+		r := fas.NewReconciler()
 		r.MinStartedMachineN = "1"
 		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
@@ -56,7 +52,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Round", func(t *testing.T) {
-		r := fas.NewReconciler(nil)
+		r := fas.NewReconciler()
 		r.MinStartedMachineN = "2.6"
 		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
@@ -68,7 +64,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Var", func(t *testing.T) {
-		r := fas.NewReconciler(nil)
+		r := fas.NewReconciler()
 		r.MinStartedMachineN = "x + y + 2"
 		r.SetValue("x", 4)
 		r.SetValue("y", 7)
@@ -82,7 +78,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Min", func(t *testing.T) {
-		r := fas.NewReconciler(nil)
+		r := fas.NewReconciler()
 		r.MinStartedMachineN = "min(x, y)"
 		r.SetValue("x", 4)
 		r.SetValue("y", 7)
@@ -96,7 +92,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Max", func(t *testing.T) {
-		r := fas.NewReconciler(nil)
+		r := fas.NewReconciler()
 		r.MinStartedMachineN = "max(x, y)"
 		r.SetValue("x", 4)
 		r.SetValue("y", 7)
@@ -110,7 +106,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Neg", func(t *testing.T) {
-		r := fas.NewReconciler(nil)
+		r := fas.NewReconciler()
 		r.MinStartedMachineN = "-2"
 		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
@@ -122,7 +118,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Blank", func(t *testing.T) {
-		r := fas.NewReconciler(nil)
+		r := fas.NewReconciler()
 		r.MinStartedMachineN = ""
 		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
@@ -134,7 +130,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("NaN", func(t *testing.T) {
-		r := fas.NewReconciler(nil)
+		r := fas.NewReconciler()
 		r.MinStartedMachineN = "x + 1"
 		r.SetValue("x", math.NaN())
 		if _, _, err := r.CalcMinStartedMachineN(); err == nil || err != fas.ErrExprNaN {
@@ -143,7 +139,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Inf", func(t *testing.T) {
-		r := fas.NewReconciler(nil)
+		r := fas.NewReconciler()
 		r.MinStartedMachineN = "1 / 0"
 		if _, _, err := r.CalcMinStartedMachineN(); err == nil || err != fas.ErrExprInf {
 			t.Fatal(err)
@@ -166,7 +162,8 @@ func TestReconciler_Scale_NoScale(t *testing.T) {
 		return &fly.MachineStartResponse{}, nil
 	}
 
-	r := fas.NewReconciler(&client)
+	r := fas.NewReconciler()
+	r.Client = &client
 	r.MinStartedMachineN = "1"
 	r.MaxStartedMachineN = "2"
 	if err := r.Reconcile(context.Background()); err != nil {
@@ -220,7 +217,8 @@ func TestReconciler_Scale_Create(t *testing.T) {
 			}
 		}
 
-		r := fas.NewReconciler(&client)
+		r := fas.NewReconciler()
+		r.Client = &client
 		r.MinCreatedMachineN, r.MaxCreatedMachineN = "4", "4"
 		if err := r.Reconcile(context.Background()); err != nil {
 			t.Fatal(err)
@@ -246,7 +244,8 @@ func TestReconciler_Scale_Create(t *testing.T) {
 			return nil, fmt.Errorf("unexpected launch invocation")
 		}
 
-		r := fas.NewReconciler(&client)
+		r := fas.NewReconciler()
+		r.Client = &client
 		r.MinCreatedMachineN = "1"
 		if err := r.Reconcile(context.Background()); err == nil || err.Error() != `no machine available to clone for scale up` {
 			t.Fatalf("unexpected error: %v", err)
@@ -278,7 +277,8 @@ func TestReconciler_Scale_Destroy(t *testing.T) {
 			return nil
 		}
 
-		r := fas.NewReconciler(&client)
+		r := fas.NewReconciler()
+		r.Client = &client
 		r.MinCreatedMachineN, r.MaxCreatedMachineN = "2", "2"
 		if err := r.Reconcile(context.Background()); err != nil {
 			t.Fatal(err)
@@ -309,7 +309,8 @@ func TestReconciler_Scale_Destroy(t *testing.T) {
 			return nil
 		}
 
-		r := fas.NewReconciler(&client)
+		r := fas.NewReconciler()
+		r.Client = &client
 		r.MaxCreatedMachineN = "0"
 		if err := r.Reconcile(context.Background()); err != nil {
 			t.Fatal(err)
@@ -345,7 +346,8 @@ func TestReconciler_Scale_Start(t *testing.T) {
 			return &fly.MachineStartResponse{}, nil
 		}
 
-		r := fas.NewReconciler(&client)
+		r := fas.NewReconciler()
+		r.Client = &client
 		r.MinStartedMachineN = "foo + 2"
 		r.MaxStartedMachineN = r.MinStartedMachineN
 		r.SetValue("foo", 1.0)
@@ -388,7 +390,8 @@ func TestReconciler_Scale_Start(t *testing.T) {
 			return &fly.MachineStartResponse{}, nil
 		}
 
-		r := fas.NewReconciler(&client)
+		r := fas.NewReconciler()
+		r.Client = &client
 		r.MinStartedMachineN = "2"
 		r.MaxStartedMachineN = r.MinStartedMachineN
 		if err := r.Reconcile(context.Background()); err != nil {
@@ -427,7 +430,8 @@ func TestReconciler_Scale_Stop(t *testing.T) {
 			return nil
 		}
 
-		r := fas.NewReconciler(&client)
+		r := fas.NewReconciler()
+		r.Client = &client
 		r.MinStartedMachineN = "1"
 		r.MaxStartedMachineN = "1"
 		if err := r.Reconcile(context.Background()); err != nil {
@@ -461,7 +465,8 @@ func TestReconciler_Scale_Stop(t *testing.T) {
 			return nil
 		}
 
-		r := fas.NewReconciler(&client)
+		r := fas.NewReconciler()
+		r.Client = &client
 		r.MinStartedMachineN = "1"
 		r.MaxStartedMachineN = "1"
 		if err := r.Reconcile(context.Background()); err != nil {
@@ -472,120 +477,6 @@ func TestReconciler_Scale_Stop(t *testing.T) {
 			t.Fatalf("MachineStopFailed=%v, want %v", got, want)
 		}
 	})
-}
-
-// Ensure prometheus registration does not blow up.
-func TestReconciler_RegisterPromMetrics(t *testing.T) {
-	reg := prometheus.NewRegistry()
-	fas.NewReconciler(nil).RegisterPromMetrics(reg)
-	if _, err := reg.Gather(); err != nil {
-		t.Fatal(err)
-	}
-}
-
-// Ensure that server can collect metrics and run reconcilation on a loop.
-func TestReconciler_StartStop(t *testing.T) {
-	if testing.Short() {
-		t.Skip("short mode enabled, skipping")
-	}
-
-	var mu sync.Mutex
-	machines := []*fly.Machine{
-		{ID: "1", State: fly.MachineStateStopped},
-		{ID: "2", State: fly.MachineStateStopped},
-		{ID: "3", State: fly.MachineStateStopped},
-		{ID: "4", State: fly.MachineStateStopped},
-	}
-
-	machinesByID := make(map[string]*fly.Machine)
-	for _, m := range machines {
-		machinesByID[m.ID] = m
-	}
-
-	// Client operates on the in-memory list of machines above.
-	var client mock.FlapsClient
-	client.ListFunc = func(ctx context.Context, state string) ([]*fly.Machine, error) {
-		mu.Lock()
-		defer mu.Unlock()
-		return machines, nil
-	}
-	client.StartFunc = func(ctx context.Context, id, nonce string) (*fly.MachineStartResponse, error) {
-		mu.Lock()
-		defer mu.Unlock()
-
-		m := machinesByID[id]
-		if m.State != fly.MachineStateStopped {
-			return nil, fmt.Errorf("unexpected state: %q", m.State)
-		}
-
-		m.State = fly.MachineStateStarted
-		return &fly.MachineStartResponse{}, nil
-	}
-	client.StopFunc = func(ctx context.Context, in fly.StopMachineInput, nonce string) error {
-		mu.Lock()
-		defer mu.Unlock()
-
-		m := machinesByID[in.ID]
-		if m.State != fly.MachineStateStarted {
-			return fmt.Errorf("unexpected state: %q", m.State)
-		}
-
-		m.State = fly.MachineStateStopped
-		return nil
-	}
-
-	// Collector will simply mirror the target value.
-	var target atomic.Int64
-	collector := mock.NewMetricCollector("target")
-	collector.CollectMetricFunc = func(ctx context.Context) (float64, error) {
-		return float64(target.Load()), nil
-	}
-
-	r := fas.NewReconciler(&client)
-	r.Interval = 100 * time.Millisecond
-	r.MinStartedMachineN = "target"
-	r.MaxStartedMachineN = r.MinStartedMachineN
-	r.Collectors = []fas.MetricCollector{collector}
-	r.Start()
-	defer r.Stop()
-
-	waitInterval := 5 * r.Interval
-
-	// Ensure no machines are started.
-	time.Sleep(waitInterval)
-	if got, want := machineCountByState(machines, fly.MachineStateStarted), 0; got != want {
-		t.Fatalf("started=%v, want %v", got, want)
-	}
-
-	t.Log("Increase target count...")
-	target.Store(2)
-	time.Sleep(waitInterval)
-	if got, want := machineCountByState(machines, fly.MachineStateStarted), 2; got != want {
-		t.Fatalf("started=%v, want %v", got, want)
-	}
-
-	t.Log("Increase target count to max...")
-	target.Store(4)
-	time.Sleep(waitInterval)
-	if got, want := machineCountByState(machines, fly.MachineStateStarted), 4; got != want {
-		t.Fatalf("started=%v, want %v", got, want)
-	}
-
-	t.Log("Exceed total machine count...")
-	target.Store(10)
-	time.Sleep(waitInterval)
-	if got, want := machineCountByState(machines, fly.MachineStateStarted), 4; got != want {
-		t.Fatalf("started=%v, want %v", got, want)
-	}
-
-	t.Log("Downscale to zero...")
-	target.Store(0)
-	time.Sleep(waitInterval)
-	if got, want := machineCountByState(machines, fly.MachineStateStarted), 0; got != want {
-		t.Fatalf("started=%v, want %v", got, want)
-	}
-
-	t.Log("Test complete")
 }
 
 func machineCountByState(a []*fly.Machine, state string) (n int) {

--- a/temporal/temporal.go
+++ b/temporal/temporal.go
@@ -70,12 +70,14 @@ func (c *MetricCollector) Name() string {
 	return c.name
 }
 
-func (c *MetricCollector) CollectMetric(ctx context.Context) (float64, error) {
+func (c *MetricCollector) CollectMetric(ctx context.Context, app string) (float64, error) {
 	// Append additional query filter, if specified.
 	query := `ExecutionStatus="Running"`
 	if c.Query != "" {
 		query += " AND (" + c.Query + ")"
 	}
+
+	query = fas.ExpandMetricQuery(ctx, query, app)
 
 	resp, err := c.client.CountWorkflow(ctx, &workflowservice.CountWorkflowExecutionsRequest{
 		Query: query,

--- a/temporal/temporal_test.go
+++ b/temporal/temporal_test.go
@@ -34,7 +34,7 @@ func TestMetricCollector_CollectMetric(t *testing.T) {
 	}
 
 	t.Log("querying metric")
-	if v, err := c.CollectMetric(context.Background()); err != nil {
+	if v, err := c.CollectMetric(context.Background(), "myapp"); err != nil {
 		t.Fatal(err)
 	} else if got, want := v, 2.0; got != want {
 		t.Fatalf("metric=%v, want %v", got, want)


### PR DESCRIPTION
This pull request changes the autoscaler so it can support more than one app. The implementation provides a pool of reconcilers that can be used against a set of applications.

- App names must match a wildcard expression (e.g. `my-app-*`)
- Apps must be in the same organization
- `FAS_API_TOKEN` must have organization-wide permissions in order to fetch app list

The list of applications is fetched when the autoscaler is initially started up and is updated based on the `FAS_APP_LIST_REFRESH_INTERVAL` setting which defaults to 1 minute. 

Fixes #22 

## Usage

To scale multiple applications, update set the organization slug and use a wildcard expression for the app name:

```
FAS_ORG="my-org"
FAS_APP_NAME="my-app-*"
```