### PR TITLE
Support creating machines in "stopped" state

### DIFF
--- a/cmd/fly-autoscaler/main.go
+++ b/cmd/fly-autoscaler/main.go
@@ -76,7 +76,7 @@ func run(ctx context.Context, args []string) error {
 			printUsage()
 			return flag.ErrHelp
 		}
-		return fmt.Errorf("litefs %s: unknown command", cmd)
+		return fmt.Errorf("fly-autoscaler %s: unknown command", cmd)
 	}
 }
 

--- a/cmd/fly-autoscaler/serve.go
+++ b/cmd/fly-autoscaler/serve.go
@@ -75,6 +75,7 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) (err error) {
 		r.MaxCreatedMachineN = maxCreatedMachineN
 		r.MinStartedMachineN = minStartedMachineN
 		r.MaxStartedMachineN = maxStartedMachineN
+		r.InitialMachineState = c.Config.InitialMachineState
 		r.Regions = c.Config.Regions
 		r.Collectors = collectors
 		return r

--- a/reconciler.go
+++ b/reconciler.go
@@ -40,6 +40,9 @@ type Reconciler struct {
 	MinStartedMachineN string
 	MaxStartedMachineN string
 
+	// Initial machine state (started or stopped)
+	InitialMachineState string
+
 	// List of collectors to fetch metric values from.
 	Collectors []MetricCollector
 
@@ -335,8 +338,9 @@ func (r *Reconciler) listMachines(ctx context.Context) ([]*fly.Machine, error) {
 
 func (r *Reconciler) createMachine(ctx context.Context, config *fly.MachineConfig, region string) (*fly.Machine, error) {
 	machine, err := r.Client.Launch(ctx, fly.LaunchMachineInput{
-		Config: config,
-		Region: region,
+		Config:     config,
+		Region:     region,
+		SkipLaunch: r.InitialMachineState == fly.MachineStateStopped,
 	})
 	if err != nil {
 		r.Stats.MachineCreateFailed.Add(1)


### PR DESCRIPTION
The PR adds support for creating machines in "stopped" state to enable
autoscaler to maintain a set of "warm" machines for proxy to autostart.

