### PR TITLE
Implement process group filtering

### DIFF
--- a/cmd/fly-autoscaler/main.go
+++ b/cmd/fly-autoscaler/main.go
@@ -118,6 +118,7 @@ type Config struct {
 	AppName                string        `yaml:"app-name"`
 	Org                    string        `yaml:"org"`
 	Regions                []string      `yaml:"regions"`
+	ProcessGroup           string        `yaml:"process-group"`
 	CreatedMachineN        string        `yaml:"created-machine-count"`
 	MinCreatedMachineN     string        `yaml:"min-created-machine-count"`
 	MaxCreatedMachineN     string        `yaml:"max-created-machine-count"`
@@ -141,6 +142,7 @@ func NewConfig() *Config {
 		Interval:               fas.DefaultReconcileInterval,
 		Timeout:                fas.DefaultReconcileTimeout,
 		AppListRefreshInterval: fas.DefaultAppListRefreshInterval,
+		ProcessGroup:           fas.DefaultProcessGroup,
 	}
 }
 
@@ -156,6 +158,10 @@ func NewConfigFromEnv() (_ *Config, err error) {
 	c.MinStartedMachineN = os.Getenv("FAS_MIN_STARTED_MACHINE_COUNT")
 	c.MaxStartedMachineN = os.Getenv("FAS_MAX_STARTED_MACHINE_COUNT")
 	c.APIToken = os.Getenv("FAS_API_TOKEN")
+
+	if s := os.Getenv("FAS_PROCESS_GROUP"); s != "" {
+		c.ProcessGroup = s
+	}
 
 	if s := os.Getenv("FAS_REGIONS"); s != "" {
 		c.Regions = strings.Split(s, ",")

--- a/cmd/fly-autoscaler/main_test.go
+++ b/cmd/fly-autoscaler/main_test.go
@@ -28,6 +28,9 @@ func TestConfig_Parse(t *testing.T) {
 	if got, want := config.Verbose, false; got != want {
 		t.Fatalf("Verbose=%v, want %v", got, want)
 	}
+	if got, want := config.ProcessGroup, "app"; got != want {
+		t.Fatalf("ProcessGroup=%v, want %v", got, want)
+	}
 
 	mc := config.MetricCollectors[0]
 	if got, want := mc.Type, "prometheus"; got != want {

--- a/cmd/fly-autoscaler/serve.go
+++ b/cmd/fly-autoscaler/serve.go
@@ -77,6 +77,7 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) (err error) {
 		r.MaxStartedMachineN = maxStartedMachineN
 		r.InitialMachineState = c.Config.InitialMachineState
 		r.Regions = c.Config.Regions
+		r.ProcessGroup = c.Config.ProcessGroup
 		r.Collectors = collectors
 		return r
 	}

--- a/etc/fly-autoscaler.yml
+++ b/etc/fly-autoscaler.yml
@@ -3,10 +3,12 @@ app-name: "TARGET_APP_NAME"
 
 # A list of regions to create machines in. Regions are chosen via round robin
 # so that machines are evenly distributed.
-# 
+#
 # If this is not specified, the autoscaler will choose a region based on the
 # regions that the app is currently running in.
-regions: ['iad', 'ord', 'sjc']
+regions: ["iad", "ord", "sjc"]
+
+process-group: "app"
 
 # This expression determines the number of machines to maintain in your app
 # after each reconciliation. If the number of machines drops below this
@@ -14,10 +16,10 @@ regions: ['iad', 'ord', 'sjc']
 # If the number of machines is above this threshold then some machines will be
 # destroyed.
 #
-# There always needs to be at least one machine in your application so the 
+# There always needs to be at least one machine in your application so the
 # autoscaler will never destroy your last machine, even if the threshold reaches
 # zero.
-# 
+#
 # You can also define separate minimum & maximum thresholds using the
 # "min_created_machine_count" & "max_created_machine_count" fields.
 created-machine-count: "ceil(queue_depth / 10)"

--- a/reconciler.go
+++ b/reconciler.go
@@ -28,6 +28,9 @@ type Reconciler struct {
 	// The reconciler uses a round-robin approach to choosing next region.
 	Regions []string
 
+	// The process group that the reconciler should watch.
+	ProcessGroup string
+
 	// Expression used for calculating the number of created machines.
 	// If current number is less than min, more machines will be created.
 	// If current number is more than max, machines will be destroyed.
@@ -121,7 +124,9 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("list machines: %w", err)
 	}
-	m := machinesByState(machines)
+
+	filtered := machinesInGroup(machines, r.ProcessGroup)
+	m := machinesByState(filtered)
 
 	// Log out stats so we know exactly what the state of the world is.
 	slog.Info("reconciling",
@@ -456,6 +461,17 @@ func machinesByState(a []*fly.Machine) map[string][]*fly.Machine {
 	m := make(map[string][]*fly.Machine)
 	for _, mach := range a {
 		m[mach.State] = append(m[mach.State], mach)
+	}
+	return m
+}
+
+func machinesInGroup(machines []*fly.Machine, group string) []*fly.Machine {
+	var m []*fly.Machine
+	for _, mach := range machines {
+		g := mach.ProcessGroup()
+		if g == group {
+			m = append(m, mach)
+		}
 	}
 	return m
 }

--- a/reconciler_pool.go
+++ b/reconciler_pool.go
@@ -18,6 +18,7 @@ const (
 	DefaultReconcileTimeout       = 30 * time.Second
 	DefaultReconcileInterval      = 15 * time.Second
 	DefaultAppListRefreshInterval = 60 * time.Second
+	DefaultProcessGroup           = "app"
 )
 
 // ReconcilerPool represents a set of reconcilers that act as a worker pool.

--- a/reconciler_pool_test.go
+++ b/reconciler_pool_test.go
@@ -49,6 +49,7 @@ func TestReconcilerPool_Run_SingleApp(t *testing.T) {
 	}
 
 	var mu sync.Mutex
+
 	machines := []*fly.Machine{
 		{ID: "1", State: fly.MachineStateStopped},
 		{ID: "2", State: fly.MachineStateStopped},


### PR DESCRIPTION
Added a new configuration parameter `FAS_PROCESS_GROUP` to allow scaling of a specific process group of the target app.