### PR TITLE
Pause reconciliation during target app deployments

### DIFF
--- a/fas.go
+++ b/fas.go
@@ -20,6 +20,7 @@ var _ FlyClient = (*fly.Client)(nil)
 type FlyClient interface {
 	GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error)
 	GetAppsForOrganization(ctx context.Context, orgID string) ([]fly.App, error)
+	GetAppCurrentReleaseMachines(ctx context.Context, appName string) (*fly.Release, error)
 }
 
 var _ FlapsClient = (*flaps.Client)(nil)

--- a/mock/fly_client.go
+++ b/mock/fly_client.go
@@ -10,8 +10,9 @@ import (
 var _ fas.FlyClient = (*FlyClient)(nil)
 
 type FlyClient struct {
-	GetOrganizationBySlugFunc  func(ctx context.Context, slug string) (*fly.Organization, error)
-	GetAppsForOrganizationFunc func(ctx context.Context, orgID string) ([]fly.App, error)
+	GetOrganizationBySlugFunc        func(ctx context.Context, slug string) (*fly.Organization, error)
+	GetAppsForOrganizationFunc       func(ctx context.Context, orgID string) ([]fly.App, error)
+	GetAppCurrentReleaseMachinesFunc func(ctx context.Context, appName string) (*fly.Release, error)
 }
 
 func (m *FlyClient) GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error) {
@@ -20,4 +21,8 @@ func (m *FlyClient) GetOrganizationBySlug(ctx context.Context, slug string) (*fl
 
 func (m *FlyClient) GetAppsForOrganization(ctx context.Context, orgID string) ([]fly.App, error) {
 	return m.GetAppsForOrganizationFunc(ctx, orgID)
+}
+
+func (m *FlyClient) GetAppCurrentReleaseMachines(ctx context.Context, appName string) (*fly.Release, error) {
+	return m.GetAppCurrentReleaseMachinesFunc(ctx, appName)
 }

--- a/reconciler_pool.go
+++ b/reconciler_pool.go
@@ -281,6 +281,21 @@ func (p *ReconcilerPool) monitorReconciler(ctx context.Context, r *Reconciler) {
 			r.AppName = info.name
 			r.Client = info.client
 
+			release, err := p.flyClient.GetAppCurrentReleaseMachines(ctx, info.name)
+			if err != nil {
+				slog.Error("get current release failed",
+					slog.String("app", info.name),
+					slog.Any("err", err))
+				continue
+			}
+
+			if release.Status == "running" {
+				slog.Warn("release in progress, skipping reconciliation",
+					slog.String("app", r.AppName),
+				)
+				continue
+			}
+
 			if err := r.CollectMetrics(ctx); err != nil {
 				slog.Error("metrics collection failed",
 					slog.String("app", info.name),

--- a/reconciler_pool_test.go
+++ b/reconciler_pool_test.go
@@ -77,6 +77,9 @@ func TestReconcilerPool_Run_SingleApp(t *testing.T) {
 			{Name: "my-app-1"},
 		}, nil
 	}
+	flyClient.GetAppCurrentReleaseMachinesFunc = func(ctx context.Context, appName string) (*fly.Release, error) {
+		return &fly.Release{InProgress: false, Status: "completed"}, nil
+	}
 
 	// Client operates on the in-memory list of machines above.
 	var flapsClient mock.FlapsClient


### PR DESCRIPTION
When working with a target app that uses the bluegreen deployment strategy, the autoscaler would attempt to stop/destroy the green machines before the deployment completed, causing the deployment to hang & fail. This commit solves the issue by checking the release status before attempting reconciliation.