### PR TITLE
fix: createN could cause an infinite loop

### DIFF
--- a/metric_collector_test.go
+++ b/metric_collector_test.go
@@ -1,29 +1,27 @@
-package fas_test
+package fas
 
 import (
 	"context"
 	"testing"
-
-	fas "github.com/superfly/fly-autoscaler"
 )
 
 func TestExpandMetricQuery(t *testing.T) {
 	t.Run("Static", func(t *testing.T) {
-		result := fas.ExpandMetricQuery(context.Background(), "foo", "my-app")
+		result := ExpandMetricQuery(context.Background(), "foo", "my-app")
 		if got, want := result, `foo`; got != want {
 			t.Fatalf("got %q, want %q", got, want)
 		}
 	})
 
 	t.Run("Bare", func(t *testing.T) {
-		result := fas.ExpandMetricQuery(context.Background(), "foo $APP_NAME bar", "my-app")
+		result := ExpandMetricQuery(context.Background(), "foo $APP_NAME bar", "my-app")
 		if got, want := result, `foo my-app bar`; got != want {
 			t.Fatalf("got %q, want %q", got, want)
 		}
 	})
 
 	t.Run("Wrapped", func(t *testing.T) {
-		result := fas.ExpandMetricQuery(context.Background(), "foo${APP_NAME}bar", "my-app")
+		result := ExpandMetricQuery(context.Background(), "foo${APP_NAME}bar", "my-app")
 		if got, want := result, `foomy-appbar`; got != want {
 			t.Fatalf("got %q, want %q", got, want)
 		}

--- a/mock/flaps_client.go
+++ b/mock/flaps_client.go
@@ -3,11 +3,8 @@ package mock
 import (
 	"context"
 
-	fas "github.com/superfly/fly-autoscaler"
 	"github.com/superfly/fly-go"
 )
-
-var _ fas.FlapsClient = (*FlapsClient)(nil)
 
 type FlapsClient struct {
 	ListFunc    func(ctx context.Context, state string) ([]*fly.Machine, error)

--- a/mock/fly_client.go
+++ b/mock/fly_client.go
@@ -3,11 +3,8 @@ package mock
 import (
 	"context"
 
-	fas "github.com/superfly/fly-autoscaler"
 	"github.com/superfly/fly-go"
 )
-
-var _ fas.FlyClient = (*FlyClient)(nil)
 
 type FlyClient struct {
 	GetOrganizationBySlugFunc  func(ctx context.Context, slug string) (*fly.Organization, error)

--- a/mock/metric_collector.go
+++ b/mock/metric_collector.go
@@ -2,11 +2,7 @@ package mock
 
 import (
 	"context"
-
-	fas "github.com/superfly/fly-autoscaler"
 )
-
-var _ fas.MetricCollector = (*MetricCollector)(nil)
 
 type MetricCollector struct {
 	name              string

--- a/reconciler_pool_test.go
+++ b/reconciler_pool_test.go
@@ -1,4 +1,4 @@
-package fas_test
+package fas
 
 import (
 	"context"
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	fas "github.com/superfly/fly-autoscaler"
 	"github.com/superfly/fly-autoscaler/mock"
 	fly "github.com/superfly/fly-go"
 )
@@ -27,7 +26,7 @@ func TestFormatWildcardAsRegexp(t *testing.T) {
 		{"my-[app]*", "^my-\\[app\\].*$"}, // escaped characters
 	} {
 		t.Run("", func(t *testing.T) {
-			if got, want := fas.FormatWildcardAsRegexp(tt.in), tt.out; got != want {
+			if got, want := FormatWildcardAsRegexp(tt.in), tt.out; got != want {
 				t.Fatalf("got %q, want %q", got, want)
 			}
 		})
@@ -37,7 +36,7 @@ func TestFormatWildcardAsRegexp(t *testing.T) {
 // Ensure prometheus registration does not blow up.
 func TestReconcilerPool_RegisterPromMetrics(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	fas.NewReconcilerPool(nil, 1).RegisterPromMetrics(reg)
+	NewReconcilerPool(nil, 1).RegisterPromMetrics(reg)
 	if _, err := reg.Gather(); err != nil {
 		t.Fatal(err)
 	}
@@ -117,19 +116,19 @@ func TestReconcilerPool_Run_SingleApp(t *testing.T) {
 		return float64(target.Load()), nil
 	}
 
-	p := fas.NewReconcilerPool(&flyClient, 1)
+	p := NewReconcilerPool(&flyClient, 1)
 	p.OrganizationSlug = "myorg"
 	p.AppName = "my-app-*"
 	p.ReconcileInterval = 100 * time.Millisecond
-	p.NewReconciler = func() *fas.Reconciler {
-		r := fas.NewReconciler()
+	p.NewReconciler = func() *Reconciler {
+		r := NewReconciler()
 		r.Client = &flapsClient
 		r.MinStartedMachineN = "target"
 		r.MaxStartedMachineN = r.MinStartedMachineN
-		r.Collectors = []fas.MetricCollector{collector}
+		r.Collectors = []MetricCollector{collector}
 		return r
 	}
-	p.NewFlapsClient = func(ctx context.Context, name string) (fas.FlapsClient, error) {
+	p.NewFlapsClient = func(ctx context.Context, name string) (FlapsClient, error) {
 		return &flapsClient, nil
 	}
 	if err := p.Open(); err != nil {

--- a/reconciler_test.go
+++ b/reconciler_test.go
@@ -1,4 +1,4 @@
-package fas_test
+package fas
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-	fas "github.com/superfly/fly-autoscaler"
 	"github.com/superfly/fly-autoscaler/mock"
 	"github.com/superfly/fly-go"
 )
@@ -21,7 +20,7 @@ func init() {
 
 func TestReconciler_Value(t *testing.T) {
 	t.Run("SetValue", func(t *testing.T) {
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.SetValue("foo", 100)
 		if v, ok := r.Value("foo"); !ok {
 			t.Fatal("expected value")
@@ -31,7 +30,7 @@ func TestReconciler_Value(t *testing.T) {
 	})
 
 	t.Run("NoValue", func(t *testing.T) {
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		if _, ok := r.Value("foo"); ok {
 			t.Fatal("expected no value")
 		}
@@ -40,7 +39,7 @@ func TestReconciler_Value(t *testing.T) {
 
 func TestReconciler_MinStartedMachineN(t *testing.T) {
 	t.Run("Constant", func(t *testing.T) {
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.MinStartedMachineN = "1"
 		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
@@ -52,7 +51,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Round", func(t *testing.T) {
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.MinStartedMachineN = "2.6"
 		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
@@ -64,7 +63,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Var", func(t *testing.T) {
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.MinStartedMachineN = "x + y + 2"
 		r.SetValue("x", 4)
 		r.SetValue("y", 7)
@@ -78,7 +77,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Min", func(t *testing.T) {
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.MinStartedMachineN = "min(x, y)"
 		r.SetValue("x", 4)
 		r.SetValue("y", 7)
@@ -92,7 +91,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Max", func(t *testing.T) {
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.MinStartedMachineN = "max(x, y)"
 		r.SetValue("x", 4)
 		r.SetValue("y", 7)
@@ -106,7 +105,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Neg", func(t *testing.T) {
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.MinStartedMachineN = "-2"
 		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
@@ -118,7 +117,7 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("Blank", func(t *testing.T) {
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.MinStartedMachineN = ""
 		if v, ok, err := r.CalcMinStartedMachineN(); err != nil {
 			t.Fatal(err)
@@ -130,18 +129,18 @@ func TestReconciler_MinStartedMachineN(t *testing.T) {
 	})
 
 	t.Run("NaN", func(t *testing.T) {
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.MinStartedMachineN = "x + 1"
 		r.SetValue("x", math.NaN())
-		if _, _, err := r.CalcMinStartedMachineN(); err == nil || err != fas.ErrExprNaN {
+		if _, _, err := r.CalcMinStartedMachineN(); err == nil || err != ErrExprNaN {
 			t.Fatal(err)
 		}
 	})
 
 	t.Run("Inf", func(t *testing.T) {
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.MinStartedMachineN = "1 / 0"
-		if _, _, err := r.CalcMinStartedMachineN(); err == nil || err != fas.ErrExprInf {
+		if _, _, err := r.CalcMinStartedMachineN(); err == nil || err != ErrExprInf {
 			t.Fatal(err)
 		}
 	})
@@ -162,7 +161,7 @@ func TestReconciler_Scale_NoScale(t *testing.T) {
 		return &fly.MachineStartResponse{}, nil
 	}
 
-	r := fas.NewReconciler()
+	r := NewReconciler()
 	r.Client = &client
 	r.MinStartedMachineN = "1"
 	r.MaxStartedMachineN = "2"
@@ -225,7 +224,7 @@ func TestReconciler_Scale_Create(t *testing.T) {
 			}
 		}
 
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.Client = &client
 		r.MinCreatedMachineN, r.MaxCreatedMachineN = "4", "4"
 		if err := r.Reconcile(context.Background()); err != nil {
@@ -252,7 +251,7 @@ func TestReconciler_Scale_Create(t *testing.T) {
 			return nil, fmt.Errorf("unexpected launch invocation")
 		}
 
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.Client = &client
 		r.MinCreatedMachineN = "1"
 		if err := r.Reconcile(context.Background()); err == nil || err.Error() != `no machine available to clone for scale up` {
@@ -285,7 +284,7 @@ func TestReconciler_Scale_Destroy(t *testing.T) {
 			return nil
 		}
 
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.Client = &client
 		r.MinCreatedMachineN, r.MaxCreatedMachineN = "2", "2"
 		if err := r.Reconcile(context.Background()); err != nil {
@@ -317,7 +316,7 @@ func TestReconciler_Scale_Destroy(t *testing.T) {
 			return nil
 		}
 
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.Client = &client
 		r.MaxCreatedMachineN = "0"
 		if err := r.Reconcile(context.Background()); err != nil {
@@ -354,7 +353,7 @@ func TestReconciler_Scale_Start(t *testing.T) {
 			return &fly.MachineStartResponse{}, nil
 		}
 
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.Client = &client
 		r.MinStartedMachineN = "foo + 2"
 		r.MaxStartedMachineN = r.MinStartedMachineN
@@ -398,7 +397,7 @@ func TestReconciler_Scale_Start(t *testing.T) {
 			return &fly.MachineStartResponse{}, nil
 		}
 
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.Client = &client
 		r.MinStartedMachineN = "2"
 		r.MaxStartedMachineN = r.MinStartedMachineN
@@ -438,7 +437,7 @@ func TestReconciler_Scale_Stop(t *testing.T) {
 			return nil
 		}
 
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.Client = &client
 		r.MinStartedMachineN = "1"
 		r.MaxStartedMachineN = "1"
@@ -473,7 +472,7 @@ func TestReconciler_Scale_Stop(t *testing.T) {
 			return nil
 		}
 
-		r := fas.NewReconciler()
+		r := NewReconciler()
 		r.Client = &client
 		r.MinStartedMachineN = "1"
 		r.MaxStartedMachineN = "1"


### PR DESCRIPTION
When r.createMachine returned an error, the loop couldn't stop since remaining-- wasn't executed.

Returning the error is much safer. The next reconciliation can start from the remaining regions.