### PR TITLE
feat: add FAS_PROCESS_GROUP config option

### DIFF
--- a/cmd/fly-autoscaler/main.go
+++ b/cmd/fly-autoscaler/main.go
@@ -118,6 +118,7 @@ type Config struct {
 	AppName                string        `yaml:"app-name"`
 	Org                    string        `yaml:"org"`
 	Regions                []string      `yaml:"regions"`
+	ProcessGroup           string        `yaml:"process-group"`
 	CreatedMachineN        string        `yaml:"created-machine-count"`
 	MinCreatedMachineN     string        `yaml:"min-created-machine-count"`
 	MaxCreatedMachineN     string        `yaml:"max-created-machine-count"`
@@ -141,6 +142,7 @@ func NewConfig() *Config {
 		Interval:               fas.DefaultReconcileInterval,
 		Timeout:                fas.DefaultReconcileTimeout,
 		AppListRefreshInterval: fas.DefaultAppListRefreshInterval,
+		ProcessGroup:           fas.DefaultProcessGroup,
 	}
 }
 
@@ -156,6 +158,10 @@ func NewConfigFromEnv() (_ *Config, err error) {
 	c.MinStartedMachineN = os.Getenv("FAS_MIN_STARTED_MACHINE_COUNT")
 	c.MaxStartedMachineN = os.Getenv("FAS_MAX_STARTED_MACHINE_COUNT")
 	c.APIToken = os.Getenv("FAS_API_TOKEN")
+
+	if s := os.Getenv("FAS_PROCESS_GROUP"); s != "" {
+		c.ProcessGroup = s
+	}
 
 	if s := os.Getenv("FAS_REGIONS"); s != "" {
 		c.Regions = strings.Split(s, ",")

--- a/cmd/fly-autoscaler/main_test.go
+++ b/cmd/fly-autoscaler/main_test.go
@@ -28,6 +28,9 @@ func TestConfig_Parse(t *testing.T) {
 	if got, want := config.Verbose, false; got != want {
 		t.Fatalf("Verbose=%v, want %v", got, want)
 	}
+	if got, want := config.ProcessGroup, "app"; got != want {
+		t.Fatalf("ProcessGroup=%v, want %v", got, want)
+	}
 
 	mc := config.MetricCollectors[0]
 	if got, want := mc.Type, "prometheus"; got != want {

--- a/cmd/fly-autoscaler/serve.go
+++ b/cmd/fly-autoscaler/serve.go
@@ -77,6 +77,7 @@ func (c *ServeCommand) Run(ctx context.Context, args []string) (err error) {
 		r.MaxStartedMachineN = maxStartedMachineN
 		r.InitialMachineState = c.Config.InitialMachineState
 		r.Regions = c.Config.Regions
+		r.ProcessGroup = c.Config.ProcessGroup
 		r.Collectors = collectors
 		return r
 	}

--- a/etc/fly-autoscaler.yml
+++ b/etc/fly-autoscaler.yml
@@ -6,7 +6,9 @@ app-name: "TARGET_APP_NAME"
 # 
 # If this is not specified, the autoscaler will choose a region based on the
 # regions that the app is currently running in.
-regions: ['iad', 'ord', 'sjc']
+regions: ["iad", "ord", "sjc"]
+
+process-group: "app"
 
 # This expression determines the number of machines to maintain in your app
 # after each reconciliation. If the number of machines drops below this
@@ -14,7 +16,7 @@ regions: ['iad', 'ord', 'sjc']
 # If the number of machines is above this threshold then some machines will be
 # destroyed.
 #
-# There always needs to be at least one machine in your application so the 
+# There always needs to be at least one machine in your application so the
 # autoscaler will never destroy your last machine, even if the threshold reaches
 # zero.
 # 

--- a/fas.go
+++ b/fas.go
@@ -20,6 +20,7 @@ var _ FlyClient = (*fly.Client)(nil)
 type FlyClient interface {
 	GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error)
 	GetAppsForOrganization(ctx context.Context, orgID string) ([]fly.App, error)
+	GetAppCurrentReleaseMachines(ctx context.Context, appName string) (*fly.Release, error)
 }
 
 var _ FlapsClient = (*flaps.Client)(nil)

--- a/metric_collector.go
+++ b/metric_collector.go
@@ -18,7 +18,7 @@ func ExpandMetricQuery(ctx context.Context, query, app string) string {
 		case "APP_NAME":
 			return app
 		default:
-			return ""
+			return os.Getenv(key)
 		}
 	})
 }

--- a/mock/fly_client.go
+++ b/mock/fly_client.go
@@ -10,8 +10,9 @@ import (
 var _ fas.FlyClient = (*FlyClient)(nil)
 
 type FlyClient struct {
-	GetOrganizationBySlugFunc  func(ctx context.Context, slug string) (*fly.Organization, error)
-	GetAppsForOrganizationFunc func(ctx context.Context, orgID string) ([]fly.App, error)
+	GetOrganizationBySlugFunc        func(ctx context.Context, slug string) (*fly.Organization, error)
+	GetAppsForOrganizationFunc       func(ctx context.Context, orgID string) ([]fly.App, error)
+	GetAppCurrentReleaseMachinesFunc func(ctx context.Context, appName string) (*fly.Release, error)
 }
 
 func (m *FlyClient) GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error) {
@@ -20,4 +21,8 @@ func (m *FlyClient) GetOrganizationBySlug(ctx context.Context, slug string) (*fl
 
 func (m *FlyClient) GetAppsForOrganization(ctx context.Context, orgID string) ([]fly.App, error) {
 	return m.GetAppsForOrganizationFunc(ctx, orgID)
+}
+
+func (m *FlyClient) GetAppCurrentReleaseMachines(ctx context.Context, appName string) (*fly.Release, error) {
+	return m.GetAppCurrentReleaseMachinesFunc(ctx, appName)
 }

--- a/reconciler_pool.go
+++ b/reconciler_pool.go
@@ -18,6 +18,7 @@ const (
 	DefaultReconcileTimeout       = 30 * time.Second
 	DefaultReconcileInterval      = 15 * time.Second
 	DefaultAppListRefreshInterval = 60 * time.Second
+	DefaultProcessGroup           = "app"
 )
 
 // ReconcilerPool represents a set of reconcilers that act as a worker pool.

--- a/reconciler_pool.go
+++ b/reconciler_pool.go
@@ -282,6 +282,21 @@ func (p *ReconcilerPool) monitorReconciler(ctx context.Context, r *Reconciler) {
 			r.AppName = info.name
 			r.Client = info.client
 
+			release, err := p.flyClient.GetAppCurrentReleaseMachines(ctx, info.name)
+			if err != nil {
+				slog.Error("get current release failed",
+					slog.String("app", info.name),
+					slog.Any("err", err))
+				continue
+			}
+
+			if release.Status == "running" {
+				slog.Warn("release in progress, skipping reconciliation",
+					slog.String("app", r.AppName),
+				)
+				continue
+			}
+
 			if err := r.CollectMetrics(ctx); err != nil {
 				slog.Error("metrics collection failed",
 					slog.String("app", info.name),

--- a/reconciler_pool_test.go
+++ b/reconciler_pool_test.go
@@ -77,6 +77,9 @@ func TestReconcilerPool_Run_SingleApp(t *testing.T) {
 			{Name: "my-app-1"},
 		}, nil
 	}
+	flyClient.GetAppCurrentReleaseMachinesFunc = func(ctx context.Context, appName string) (*fly.Release, error) {
+		return &fly.Release{InProgress: false, Status: "completed"}, nil
+	}
 
 	// Client operates on the in-memory list of machines above.
 	var flapsClient mock.FlapsClient


### PR DESCRIPTION
Added a new configuration parameter FAS_PROCESS_GROUP to allow scaling of a specific process group of the target app.

This is an update of https://github.com/superfly/fly-autoscaler/pull/33 because it seems abandonned. I removed the whitespace/markdown changes as asked by @kzys

and added the other commits on the fork, that were not in the original PR