### PR TITLE
fix: memory leak from deferred cancel in infinite loop

### DIFF
--- a/reconciler_pool.go
+++ b/reconciler_pool.go
@@ -268,34 +268,38 @@ func (p *ReconcilerPool) updateAppNameList(ctx context.Context) error {
 
 // monitorReconciler monitors the work queue and passes apps to the reconciler.
 func (p *ReconcilerPool) monitorReconciler(ctx context.Context, r *Reconciler) {
-	errReconciliationTimeout := fmt.Errorf("reconciliation timeout")
-
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case info := <-p.ch:
-			ctx, cancel := context.WithTimeoutCause(p.ctx, p.ReconcileTimeout, errReconciliationTimeout)
-			defer cancel()
-
-			r.AppName = info.name
-			r.Client = info.client
-
-			if err := r.CollectMetrics(ctx); err != nil {
-				slog.Error("metrics collection failed",
-					slog.String("app", info.name),
-					slog.Any("err", err))
-				continue
-			}
-
-			if err := r.Reconcile(ctx); err != nil {
-				slog.Error("reconciliation failed",
-					slog.String("app", info.name),
-					slog.Any("err", err))
-				continue
-			}
-
+			p.processWork(r, info)
 		}
+	}
+}
+
+// processWork handles a single reconciliation cycle for a given app.
+// Extracted from monitorReconciler so that defer cancel() runs after each iteration.
+func (p *ReconcilerPool) processWork(r *Reconciler, info appInfo) {
+	errReconciliationTimeout := fmt.Errorf("reconciliation timeout")
+	ctx, cancel := context.WithTimeoutCause(p.ctx, p.ReconcileTimeout, errReconciliationTimeout)
+	defer cancel()
+
+	r.AppName = info.name
+	r.Client = info.client
+
+	if err := r.CollectMetrics(ctx); err != nil {
+		slog.Error("metrics collection failed",
+			slog.String("app", info.name),
+			slog.Any("err", err))
+		return
+	}
+
+	if err := r.Reconcile(ctx); err != nil {
+		slog.Error("reconciliation failed",
+			slog.String("app", info.name),
+			slog.Any("err", err))
+		return
 	}
 }
 


### PR DESCRIPTION
   In monitorReconciler, defer cancel() was called inside a for loop.
   Since defer runs when the function returns (not the loop iteration),
   the context cancellation functions accumulated forever, leaking
   goroutines and memory.

   Extract the loop body into a separate processWork method so defer
   cancel() executes after each reconciliation cycle.